### PR TITLE
Potential fix for code scanning alert no. 180: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_x86.yml
+++ b/.github/workflows/build_x86.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   SCCACHE_GHA_ENABLED: "true"


### PR DESCRIPTION
Potential fix for [https://github.com/FyraStack/odorobo/security/code-scanning/180](https://github.com/FyraStack/odorobo/security/code-scanning/180)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged by default.  
Best single fix without changing functionality: define workflow-level permissions right after the `on:` section (or before `jobs:`), with `contents: read`. This applies to all jobs unless overridden and satisfies CodeQL’s requirement.

**File to edit:** `.github/workflows/build_x86.yml`  
**Change:** insert:

```yml
permissions:
  contents: read
```

No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
