### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_riscv_rva23.yml
+++ b/.github/workflows/build_riscv_rva23.yml
@@ -4,6 +4,10 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+  actions: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/FyraStack/odorobo/security/code-scanning/3](https://github.com/FyraStack/odorobo/security/code-scanning/3)

Add an explicit `permissions` block to `.github/workflows/build_riscv_rva23.yml` at the workflow root (best here since there is only one job and all current steps can share the same baseline).  
Use:

- `contents: read` (recommended minimum for checkout/repo read access)
- `actions: read` (safe for action metadata access; optional but commonly included)

No new imports, methods, or dependencies are needed.  
Edit region: directly after the `on:` trigger block and before `env:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
