### PR TITLE
VM Agents: Networking

### DIFF
--- a/.github/workflows/build_x86.yml
+++ b/.github/workflows/build_x86.yml
@@ -19,7 +19,8 @@ jobs:
     - uses: rui314/setup-mold@v1
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.9
-    
+    - name: Install dependencies
+      run: apt-get install -y libmnl-dev libnftnl-dev clang
     - name: Build
       run: cargo build --verbose --release
     - name: Upload artifact - agent

--- a/.github/workflows/build_x86.yml
+++ b/.github/workflows/build_x86.yml
@@ -11,33 +11,32 @@ env:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - uses: rui314/setup-mold@v1
-    - name: Run sccache-cache
-      uses: mozilla-actions/sccache-action@v0.0.9
-    - name: Install dependencies
-      run: apt-get install -y libmnl-dev libnftnl-dev clang
-    - name: Build
-      run: cargo build --verbose --release
-    - name: Upload artifact - agent
-      uses: actions/upload-artifact@v7
-      with:
-        archive: false
-        name: odorobo-agent-x86
-        path: |
-          target/release/odorobo-agent
-          
-    - name: Upload artifact - odoroboctl
-      uses: actions/upload-artifact@v7
-      with:
-        archive: false
-        name: odoroboctl-x86
-        path: |
-          target/release/odoroboctl
-          
-    - name: Run tests
-      run: cargo test --verbose
+      - uses: actions/checkout@v4
+      - uses: rui314/setup-mold@v1
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.9
+      - name: Install dependencies
+        run: apt-get install -y clang
+      - name: Build
+        run: cargo build --verbose --release
+      - name: Upload artifact - agent
+        uses: actions/upload-artifact@v7
+        with:
+          archive: false
+          name: odorobo-agent-x86
+          path: |
+            target/release/odorobo-agent
+
+      - name: Upload artifact - odoroboctl
+        uses: actions/upload-artifact@v7
+        with:
+          archive: false
+          name: odoroboctl-x86
+          path: |
+            target/release/odoroboctl
+
+      - name: Run tests
+        run: cargo test --verbose

--- a/.github/workflows/build_x86.yml
+++ b/.github/workflows/build_x86.yml
@@ -18,8 +18,7 @@ jobs:
       - uses: rui314/setup-mold@v1
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
-      - name: Install dependencies
-        run: apt-get install -y clang
+
       - name: Build
         run: cargo build --verbose --release
       - name: Upload artifact - agent

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -13,8 +13,7 @@ on:
   push:
   pull_request:
   schedule:
-    - cron: '39 6 * * 6'
-
+    - cron: "39 6 * * 6"
 
 env:
   CARGO_TERM_COLOR: always
@@ -33,6 +32,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Install dependencies
+        run: apt-get install -y libmnl-dev libnftnl-dev clang
+
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af #@v1
         with:
@@ -41,18 +43,15 @@ jobs:
           components: clippy
           override: true
 
-  
       - uses: rui314/setup-mold@v1
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
-
 
       - name: Install required cargo
         run: cargo install clippy-sarif sarif-fmt
 
       - name: Run rust-clippy
-        run:
-          cargo clippy
+        run: cargo clippy
           --all-features
           --message-format=json | clippy-sarif | tee rust-clippy-results.sarif | sarif-fmt
         continue-on-error: true

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install dependencies
-        run: apt-get install -y libmnl-dev libnftnl-dev clang
+        run: apt-get install -y clang
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af #@v1

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -32,9 +32,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install dependencies
-        run: apt-get install -y clang
-
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af #@v1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,7 +88,7 @@ dependencies = [
  "cfg-if",
  "http 1.4.0",
  "indexmap",
- "schemars",
+ "schemars 0.9.0",
  "serde",
  "serde_json",
  "serde_qs",
@@ -2069,6 +2069,10 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "schemars 0.8.22",
+ "serde",
+]
 
 [[package]]
 name = "iri-string"
@@ -2706,6 +2710,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "mnl-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0f3c607af12ed53f3cade8ee7adeced5533800abc0b07f5b6bdc7081d1e0d4c"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "moka"
 version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2839,6 +2853,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "nftnl"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a530f904e31675dc9d2e3a5c166a844dffc3dad644205fe5abb638f4e9e75d9b"
+dependencies = [
+ "bitflags",
+ "log",
+ "nftnl-sys",
+ "nix",
+]
+
+[[package]]
+name = "nftnl-sys"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffa28b4c81eea6a8a4fd454634d425e1a559250a50a926de4517dd9607fe9a4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "mnl-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2963,11 +3001,14 @@ dependencies = [
  "hyper-util",
  "hyperlocal",
  "if-addrs 0.13.4",
+ "ipnet",
  "kameo",
  "libc",
  "libp2p",
+ "nftnl",
  "odorobo-shared",
  "random-port",
+ "rtnetlink",
  "serde",
  "serde_json",
  "stable-eyre",
@@ -3000,7 +3041,7 @@ dependencies = [
  "odorobo-shared",
  "optional_struct",
  "reqwest",
- "schemars",
+ "schemars 0.9.0",
  "serde",
  "serde_json",
  "stable-eyre",
@@ -3213,6 +3254,12 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "polling"
@@ -3834,6 +3881,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2710,27 +2710,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mnl"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528ab362254419b09757228dc96e0d834e75392c52870d759df2274753007065"
-dependencies = [
- "libc",
- "log",
- "mnl-sys",
-]
-
-[[package]]
-name = "mnl-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0f3c607af12ed53f3cade8ee7adeced5533800abc0b07f5b6bdc7081d1e0d4c"
-dependencies = [
- "libc",
- "pkg-config",
-]
-
-[[package]]
 name = "moka"
 version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2864,27 +2843,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "nftnl"
-version = "0.9.1"
+name = "nftables"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a530f904e31675dc9d2e3a5c166a844dffc3dad644205fe5abb638f4e9e75d9b"
+checksum = "3c57e7343eed9e9330e084eef12651b15be3c8ed7825915a0ffa33736b852bed"
 dependencies = [
- "bitflags",
- "log",
- "nftnl-sys",
- "nix",
-]
-
-[[package]]
-name = "nftnl-sys"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cffa28b4c81eea6a8a4fd454634d425e1a559250a50a926de4517dd9607fe9a4"
-dependencies = [
- "cfg-if",
- "libc",
- "mnl-sys",
- "pkg-config",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "strum",
+ "strum_macros",
+ "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]
@@ -3016,8 +2987,7 @@ dependencies = [
  "kameo",
  "libc",
  "libp2p",
- "mnl",
- "nftnl",
+ "nftables",
  "odorobo-shared",
  "random-port",
  "rtnetlink",
@@ -3266,12 +3236,6 @@ dependencies = [
  "der",
  "spki",
 ]
-
-[[package]]
-name = "pkg-config"
-version = "0.3.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "polling"
@@ -3915,7 +3879,20 @@ dependencies = [
  "dyn-clone",
  "indexmap",
  "ref-cast",
- "schemars_derive",
+ "schemars_derive 0.9.0",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive 1.2.1",
  "serde",
  "serde_json",
 ]
@@ -3925,6 +3902,18 @@ name = "schemars_derive"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5016d94c77c6d32f0b8e08b781f7dc8a90c2007d4e77472cc2807bc10a8438fe"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4224,6 +4213,24 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "subtle"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2710,6 +2710,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "mnl"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ab362254419b09757228dc96e0d834e75392c52870d759df2274753007065"
+dependencies = [
+ "libc",
+ "log",
+ "mnl-sys",
+]
+
+[[package]]
 name = "mnl-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3005,6 +3016,7 @@ dependencies = [
  "kameo",
  "libc",
  "libp2p",
+ "mnl",
  "nftnl",
  "odorobo-shared",
  "random-port",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ odoroboctl = { path = "odoroboctl" }
 odorobo-manager = { path = "odorobo-manager" }
 dotenvy = "0.15"
 clap = { version = "4", features = ["derive", "env"] }
+ipnet = {version = "2.12.0", features = ["serde", "schemars08"]}
 # these are for performance optimizations, based on https://nnethercote.github.io/perf-book/build-configuration.html#optimization-level
 # these options can take a while to compile (up to 5-10 minutes), so its really only necessary for production binaries.
 # also look in .cargo/config.toml for info on microarchitecture optimizations.

--- a/Containerfile
+++ b/Containerfile
@@ -4,9 +4,7 @@ RUN apk add \
 	gcc \
 	musl-dev \
 	rustup \
-	zig \
-	libnftnl-dev \
-	libmnl-dev
+	zig
 RUN rustup-init \
 	--profile minimal \
 	--target riscv64a23-unknown-linux-gnu \

--- a/Containerfile
+++ b/Containerfile
@@ -4,7 +4,9 @@ RUN apk add \
 	gcc \
 	musl-dev \
 	rustup \
-	zig
+	zig \
+	libnftnl-dev \
+	libmnl-dev
 RUN rustup-init \
 	--profile minimal \
 	--target riscv64a23-unknown-linux-gnu \

--- a/README.md
+++ b/README.md
@@ -62,14 +62,19 @@ Now apply the [Cloud Hypervisor VM spec](https://github.com/cloud-hypervisor/clo
 odoroboctl create my-vm --boot ./my-vm.json
 ```
 
-To connect directly on the host, look up the PTY path from the VM info:
+To connect directly on the host, connect to the VM's serial console socket in its runtime directory:
 
 ```bash
-odoroboctl info my-vm  # find config.serial.file, e.g. /dev/pts/3
-screen /dev/pts/3
+sudo socat -,rawer UNIX-CONNECT:/run/odorobo/vms/01KPBBXKK0R0M09VN7G6R6R3JF/console.sock
 ```
 
-See [docs/console.md](docs/console.md) for WebSocket console usage and integration details.
+Replace the VM ID in the socket path with your VM's ID. The serial console socket is created at:
+
+```text
+/run/odorobo/vms/<vmid>/console.sock
+```
+
+See [docs/console.md](docs/console.md) for direct serial socket access, WebSocket console usage, and integration details.
 
 For more advanced usage, Odorobo Agent also exposes a passthrough route for the local Cloud Hypervisor API, allowing you to call the full Cloud Hypervisor API directly through the agent's REST API
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Build the Agent binary with `cargo build --release` and run it on the host machi
 
 ```bash
 # Install dependencies (fedora)
-sudo dnf in -y libmnl-devel libnftnl-devel clang-devel
+sudo dnf in -y clang-devel nftables
 
 # Build the Agent
 cargo build --release

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Odorobo Agent is meant to be run as a system agent on each bare-metal node (or a
 Build the Agent binary with `cargo build --release` and run it on the host machine. The Agent will listen for commands from the Gateway to create, manage, and delete VMs.
 
 ```bash
+# Install dependencies (fedora)
+sudo dnf in -y libmnl-devel libnftnl-devel clang-devel
+
 # Build the Agent
 cargo build --release
 # Run the Agent (requires write permissions to /run/odorobo, and access to systemd's system session bus

--- a/docs/console.md
+++ b/docs/console.md
@@ -1,39 +1,74 @@
-# Console API
+# Console Integration
 
-## PTY over WebSocket
+Odorobo configures the guest serial console as a UNIX socket owned by the agent rather than relying on a host PTY allocated by Cloud Hypervisor.
+This gives each VM a stable, deterministic host-side serial endpoint under the VM runtime directory.
+
+Currently, Odorobo's console integration supports the following access patterns:
+
+- **Direct host-side serial socket access**: Each VM's serial console is configured as a UNIX socket at `/run/odorobo/vms/<vmid>/console.sock`. This can be connected to directly from the host with tools such as `socat`.
+- **WebSocket console bridge**: The agent exposes a WebSocket endpoint at `GET /vms/{vmid}/console` and proxies the VM's serial socket in both directions for browser or CLI clients.
+
+## Serial socket configuration
+
+During VM config transformation, Odorobo rewrites the serial console configuration to use Cloud Hypervisor's socket-backed serial mode.
+For a VM with ID `01KPBBXKK0R0M09VN7G6R6R3JF`, the serial console socket will be created at:
+
+```text
+/run/odorobo/vms/01KPBBXKK0R0M09VN7G6R6R3JF/console.sock
+```
+
+This path is stable for the lifetime of the VM runtime directory and is derived from the VM ID.
+
+## Direct host access
+
+To connect directly to the guest serial console on the host, connect to the socket with `socat`:
+
+```bash
+sudo socat -,rawer UNIX-CONNECT:/run/odorobo/vms/01KPBBXKK0R0M09VN7G6R6R3JF/console.sock
+```
+
+This is currently the simplest direct way to verify that the guest serial console is alive and accepting input.
+
+A few notes about this connection style:
+
+- `rawer` is important so local terminal processing does not interfere with the serial byte stream.
+- You will typically need sufficient permissions to access the runtime directory and socket, which is why `sudo` is commonly required.
+- This is a raw serial stream, not a terminal emulator. Line editing, ANSI handling, scrollback, and rendering are provided by your terminal, not by Odorobo.
+
+## WebSocket bridge
 
 The agent exposes a VM console bridge at:
 
 `GET /vms/{vmid}/console`
 
-This endpoint upgrades to a WebSocket and proxies the VM's serial console PTY in both directions. Cloud Hypervisor allocates a PTY for the serial console; the agent looks up the PTY path via the CH API and opens it on behalf of the client.
+This endpoint upgrades to a WebSocket and proxies the VM's serial console socket in both directions.
 
 ## Connection behavior
 
 - Connect with a standard WebSocket client to `ws://<agent-host>:8890/vms/<vmid>/console`
-- The upgrade succeeds only if the VM exists and the agent can open its console PTY
+- The upgrade succeeds only if the VM exists and the agent can open its serial console socket
 - If the VM does not exist, the HTTP request returns `404`
-- If the PTY cannot be opened, the HTTP request returns `500`
+- If the serial socket cannot be opened, the HTTP request returns `500`
 - After the upgrade completes, terminal bytes flow over the socket until either side disconnects
+
+In practice, treat this as a raw byte stream carried over WebSocket frames.
 
 ## Frame semantics
 
 - Client -> VM:
-  - WebSocket `Binary` frames are written to the PTY as-is
+  - WebSocket `Binary` frames are written to the serial socket as-is
   - WebSocket `Text` frames are reserved for JSON control messages
 - VM -> Client:
-  - A `{"type":"connected","vm_id":"..."}` text frame is sent immediately on upgrade before any PTY data
-  - PTY output is sent back as WebSocket `Binary` frames
+  - A `{"type":"connected","vm_id":"..."}` text frame is sent immediately on upgrade before any console data
+  - Serial console output is sent back as WebSocket `Binary` frames
   - Server control or protocol errors are sent as WebSocket `Text` frames containing JSON
 - Control frames:
   - WebSocket `Ping` receives a `Pong`
   - WebSocket `Close` closes the session
 
-In practice, treat this as a raw byte stream carried over WebSocket frames.
-
 ## Resize message
 
-Clients resize the PTY by sending a JSON text frame like:
+Clients resize the console session by sending a JSON text frame like:
 
 ```json
 {"type":"resize","cols":120,"rows":40}
@@ -45,7 +80,7 @@ Optional pixel dimensions are also supported:
 {"type":"resize","cols":120,"rows":40,"x_pixels":960,"y_pixels":720}
 ```
 
-The agent applies the new TTY window size on the host PTY with `TIOCSWINSZ`, so the guest can observe the updated size through normal terminal mechanisms.
+The agent applies the new terminal window size on the host-side console endpoint so the guest can observe the updated size through normal terminal mechanisms.
 
 ## Reset-session message
 
@@ -55,7 +90,7 @@ Clients can ask the agent to try to return the console to a fresh login-like sta
 {"type":"reset_session"}
 ```
 
-This sends a conservative control sequence to the PTY:
+This sends a conservative control sequence to the serial console:
 
 - `Ctrl-C` to interrupt a foreground shell command if possible
 - `Enter` to try to land on a clean prompt
@@ -65,16 +100,16 @@ This is best-effort only. The guest decides what those bytes mean.
 
 ## Important implementation notes
 
-- Do not assume one terminal message maps to one WebSocket frame; PTY output is chunked arbitrarily
+- Do not assume one terminal message maps to one WebSocket frame; serial output is chunked arbitrarily
 - Send terminal input as binary bytes, not text frames
 - Text frames should be treated as a small control channel for messages like resize requests, reset requests, and error events
 - If the server receives an invalid control message, it responds with a JSON text frame like `{"type":"error","message":"..."}` and keeps the session open
 - This API is transport-only; terminal emulation, ANSI parsing, scrollback, and rendering are client responsibilities
-- `reset_session` is heuristic: it works best when the guest runs a normal login shell or `agetty` on `hvc0`
+- `reset_session` is heuristic: it works best when the guest runs a normal login shell or `agetty` on the configured serial console
 - On serial-backed Linux sessions, `Ctrl-D` only causes a logout when the foreground process interprets it as EOF
 - If the guest is running `vim`, `less`, a full-screen app, or a raw-mode program, `reset_session` may not produce a fresh login prompt
-- For deterministic fresh sessions, configure the guest to respawn `getty` on the console device after shell exit
-- The PTY path changes if the VM is restarted or migrated; the WebSocket connection must be re-established after migration
+- For deterministic fresh sessions, configure the guest to respawn `getty` on the serial console after shell exit
+- The console socket path is stable for a given VM runtime directory, but the socket itself is recreated when the VM is restarted or migrated, so clients must reconnect after those events
 
 ## Browser example
 
@@ -85,7 +120,6 @@ const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 
 ws.addEventListener("open", () => {
-  // Send a command to the guest console.
   ws.send(encoder.encode("uname -a\n"));
   ws.send(JSON.stringify({ type: "resize", cols: 120, rows: 40 }));
 });
@@ -133,4 +167,13 @@ function resetSession() {
 websocat --binary ws://127.0.0.1:8890/vms/my-vm/console
 ```
 
-This is the simplest way to verify the bridge works before integrating it into a browser terminal such as xterm.js.
+This is the simplest way to verify the WebSocket bridge works before integrating it into a browser terminal such as xterm.js.
+
+## Summary
+
+For most debugging and operator workflows:
+
+- use `socat` when you are already on the host and want a direct raw serial connection
+- use the WebSocket bridge when you want remote access or browser integration
+
+Both paths ultimately connect to the same guest serial console socket managed by the agent.

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -1,0 +1,83 @@
+# Networking Integration
+
+Odorobo adds a networking integration layer on top of Cloud Hypervisor's network device support, using config transforms to convert Odorobo-local network references into concrete TAP device names that Cloud Hypervisor can use directly.
+This allows users to specify guest network attachments in a stable, Odorobo-aware way, while letting the agent derive deterministic host-side interface names instead of relying on Cloud Hypervisor to auto-generate TAP names at runtime.
+
+Currently, Odorobo's networking transform supports the following backend:
+
+- **Odorobo-managed TAP naming**: Specify a network attachment by setting the network device `id` to the `net://` URI scheme, e.g. `net://devnet`. Odorobo will detect the `net://` scheme during config transformation, validate the network identifier, and rewrite the Cloud Hypervisor `NetConfig` to use a deterministic TAP device name derived from the VM ID and the network ID.
+
+To use the networking transformer, specify the desired `net://` URI in the `id` field of a network device in your VM config. For example:
+
+```json
+{
+  ...
+  "net": [
+    {
+      "id": "net://devnet",
+      "mac": "46:59:52:67:67:67"
+    }
+  ]
+}
+```
+
+Odorobo will automatically detect the `net://` scheme and transform it before VM creation into a concrete Cloud Hypervisor network device definition. For a VM with ID `01KPB9AMVWXC2D1PF4W6E7MHWT`, the transformed config would look like:
+
+```json
+{
+  ...
+  "net": [
+    {
+      "id": "devnet",
+      "tap": "vmtap-7mhwt-vnet",
+      "mac": "46:59:52:67:67:67"
+    }
+  ]
+}
+```
+
+The transformed `tap` field gives Cloud Hypervisor a known host-side TAP name to use, and the transformed `id` field removes the Odorobo-local `net://` prefix so the runtime configuration contains only the concrete network identifier.
+
+The TAP name is deterministic per `(vmid, network_id)` pair and is generated using the following rules:
+
+- The TAP name format is `vmtap-<vmid-suffix>-<network-id-suffix>`.
+- Linux interface names are limited in length, so Odorobo truncates both the VM ID and network ID components to fit within the interface name limit.
+- Odorobo keeps the **suffix** of the VM ID rather than the prefix, because ULID prefixes are timestamp-derived and less useful for uniqueness when many VMs are created close together.
+- The network ID is sanitized to a conservative Linux-interface-safe character set.
+- Network IDs may only contain ASCII alphanumeric characters, `_`, and `-`.
+
+This transform currently only rewrites the VM configuration.
+It does not yet imply more advanced network orchestration semantics such as routed IPv6 guest networking, dynamic TAP discovery from Cloud Hypervisor, or arbitrary external network backend resolution.
+
+## Network modes
+
+Odorobo's agent-side network configuration currently supports two host networking modes:
+
+- **Host-only NAT**: A private guest bridge with a host-side gateway IP and outbound NAT through a configured upstream interface.
+- **Bridged**: A flat bridge mode where the agent ensures the bridge exists and has the configured host address, but the operator is responsible for attaching any physical uplink to the bridge.
+
+In Host-only NAT mode, the bridge itself carries the guest gateway IP on the private subnet, and guest TAP devices are attached to that bridge.
+Outbound NAT is currently implemented as an IPv4-only masquerade rule in a dedicated Odorobo-owned nftables table.
+
+> [!NOTE]
+> Host-only NAT is intentionally IPv4-only for now.
+>
+> Although nftables can match interfaces in dual-stack tables, Odorobo's current host-only networking model is explicitly built around IPv4 guest subnet and gateway configuration.
+> Enabling IPv6 NAT would be a larger policy decision, because it would implicitly opt Odorobo into an IPv6 guest-networking story and NAT66 behavior.
+> Until Odorobo has intentional IPv6 guest-network design, host-only NAT remains scoped to IPv4.
+
+## DHCP integration
+
+If DHCP is configured in the agent's networking config, Odorobo starts `dnsmasq` bound to the configured guest bridge and serves leases for the configured subnet and range.
+This is intended for host-only private guest networks where Odorobo owns the bridge and guest-side address distribution.
+
+## Limitations
+
+At the moment, the `net://` transformer is intentionally conservative:
+
+- It only interprets `net://<network_id>` in the network device `id` field.
+- It does not currently resolve arbitrary remote or provider-backed virtual networks.
+- It does not currently create a higher-level virtual network inventory or multi-tenant network object model.
+- It relies on deterministic TAP naming instead of Cloud Hypervisor runtime TAP discovery, because Cloud Hypervisor does not reliably reflect auto-generated TAP device names back into VM info after boot.
+
+This makes the current networking integration a practical first step: Odorobo can transform user-friendly network references into stable Cloud Hypervisor network config while keeping host-side naming deterministic and debuggable.

--- a/odorobo-agent/Cargo.toml
+++ b/odorobo-agent/Cargo.toml
@@ -48,4 +48,5 @@ ulid = { workspace = true }
 ipnet = { workspace = true }
 rtnetlink = "0.20.0"
 nftnl = { version = "0.9.1", features = ["nftnl-1-1-3"] }
+mnl = "0.3.1"
 

--- a/odorobo-agent/Cargo.toml
+++ b/odorobo-agent/Cargo.toml
@@ -45,3 +45,7 @@ sysinfo = "0.38.4"
 bytesize = "2.3.1"
 odorobo-shared = { workspace = true }
 ulid = { workspace = true }
+ipnet = { workspace = true }
+rtnetlink = "0.20.0"
+nftnl = { version = "0.9.1", features = ["nftnl-1-1-3"] }
+

--- a/odorobo-agent/Cargo.toml
+++ b/odorobo-agent/Cargo.toml
@@ -47,6 +47,4 @@ odorobo-shared = { workspace = true }
 ulid = { workspace = true }
 ipnet = { workspace = true }
 rtnetlink = "0.20.0"
-nftnl = { version = "0.9.1", features = ["nftnl-1-1-3"] }
-mnl = "0.3.1"
-
+nftables = { version = "0.6.3", features = ["tokio"] }

--- a/odorobo-agent/config.json
+++ b/odorobo-agent/config.json
@@ -1,4 +1,18 @@
 {
   "datacenter": "Dev",
-  "region": "Dev"
+  "region": "Dev",
+  "network": {
+    "dhcp_config": {
+      "range": ["10.10.100.100", "10.10.100.200"],
+      "subnet": "10.10.100.0/24",
+      "lease_time": "12h"
+    },
+    "network_mode": {
+      "HostonlyNat": {
+        "bridge": "vmbr0",
+        "subnet": "10.10.100.0/24",
+        "gateway": "10.10.100.1"
+      }
+    }
+  }
 }

--- a/odorobo-agent/src/actor/mod.rs
+++ b/odorobo-agent/src/actor/mod.rs
@@ -1,6 +1,7 @@
-use crate::state::provisioning::actor::VMActor;
+use crate::{networking::actor::NetworkAgentActor, state::provisioning::actor::VMActor};
 use ahash::AHashMap;
 use bytesize::ByteSize;
+use ipnet::Ipv4Net;
 use kameo::prelude::*;
 use odorobo_shared::{
     messages::{Ping, Pong, debug::PanicAgent, vm::*},
@@ -8,8 +9,8 @@ use odorobo_shared::{
 };
 use serde::{Deserialize, Serialize};
 use stable_eyre::{Report, Result};
-use std::fs;
 use std::ops::ControlFlow;
+use std::{fs, net::Ipv4Addr};
 use sysinfo::System;
 use tracing::{error, info, trace, warn};
 use ulid::Ulid;
@@ -22,6 +23,7 @@ pub struct AgentActor {
     pub memory: ByteSize,
     pub config: Config,
     pub vms: AHashMap<Ulid, ActorRef<VMActor>>,
+    // pub network_actor: ActorRef<NetworkAgentActor>,
 }
 
 /// Gets the system hostname
@@ -43,6 +45,88 @@ fn default_datacenter() -> String {
 fn default_region() -> String {
     warn!("No region specified, defaulting to Local");
     "Local".into()
+}
+
+fn default_bridge_name() -> String {
+    "vmbr0".into()
+}
+
+fn default_subnet() -> Ipv4Net {
+    "10.0.0.0/24".parse().unwrap()
+}
+
+fn default_gateway() -> Ipv4Addr {
+    "10.0.0.1".parse().unwrap()
+}
+
+fn default_upstream_iface() -> String {
+    "eth0".into()
+}
+
+/// DHCP server config
+///
+/// config options for dnsmasq
+///
+/// this configures what options
+// --no-daemon
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct DhcpConfig {
+    pub upstream_iface: String,
+    pub range: (Ipv4Addr, Ipv4Addr),
+    pub mask: Ipv4Net,
+    /// lease time for DHCP clients
+    ///
+    /// example: 12h, 6h, 30m
+    pub lease_time: String,
+}
+
+// TODO: move config into a separate module
+#[derive(Serialize, Deserialize, Default, Clone)]
+pub struct NetworkConfig {
+    pub dhcp_config: Option<DhcpConfig>,
+    pub network_mode: NetworkMode,
+}
+
+/// L3 routing configuration for guests
+#[derive(Serialize, Deserialize, Clone)]
+pub enum NetworkMode {
+    /// Private guest bridge with host-side gateway and outbound NAT.
+    HostonlyNat {
+        #[serde(default = "default_bridge_name")]
+        bridge: String,
+        #[serde(default = "default_subnet")]
+        subnet: Ipv4Net,
+        #[serde(default = "default_gateway")]
+        gateway: Ipv4Addr,
+        #[serde(default = "default_upstream_iface")]
+        upstream_iface: String,
+    },
+    /// Flat bridge mode for operator-managed uplinks.
+    ///
+    /// The agent should only ensure that the bridge exists, is up, and has the
+    /// configured host address on it. It should not automatically enslave a
+    /// physical uplink into the bridge. Operators are expected to attach the
+    /// upstream interface themselves and handle any host networking migration
+    /// required for their environment.
+    ///
+    /// Per-VM TAP devices can still be attached to this bridge in the same way
+    /// as NAT mode.
+    Bridged {
+        bridge: String,
+        subnet: Ipv4Net,
+        gateway: Ipv4Addr,
+    },
+}
+
+impl Default for NetworkMode {
+    fn default() -> Self {
+        Self::HostonlyNat {
+            bridge: default_bridge_name(),
+            subnet: default_subnet(),
+            gateway: default_gateway(),
+            upstream_iface: default_upstream_iface(),
+        }
+    }
 }
 
 // The infra team wants a config file on the box where they can set info specific for the box its on.
@@ -69,6 +153,8 @@ pub struct Config {
     /// Arbitrary annotations that can be used
     #[serde(default)]
     pub annotations: AHashMap<String, String>,
+    #[serde(default)]
+    pub network: NetworkConfig,
 }
 
 impl AgentActor {
@@ -84,10 +170,15 @@ impl Actor for AgentActor {
     type Args = ();
     type Error = Report;
 
-    async fn on_start(_state: Self::Args, _actor_ref: ActorRef<Self>) -> Result<Self> {
+    async fn on_start(_state: Self::Args, actor_ref: ActorRef<Self>) -> Result<Self> {
         // TODO: ask infra team where they want this on the box
         let file = fs::File::open("config.json").expect("file should open read only");
         let config: Config = serde_json::from_reader(file).expect("file should be proper JSON");
+
+        // spawn networking actor
+        let network_actor: ActorRef<NetworkAgentActor> =
+            NetworkAgentActor::spawn_link(&actor_ref, config.network.clone()).await;
+        network_actor.register("network_actor").await?;
 
         let sys = System::new_all();
 

--- a/odorobo-agent/src/actor/mod.rs
+++ b/odorobo-agent/src/actor/mod.rs
@@ -73,7 +73,7 @@ fn default_upstream_iface() -> String {
 pub struct DhcpConfig {
     pub upstream_iface: String,
     pub range: (Ipv4Addr, Ipv4Addr),
-    pub mask: Ipv4Net,
+    pub subnet: Ipv4Net,
     /// lease time for DHCP clients
     ///
     /// example: 12h, 6h, 30m

--- a/odorobo-agent/src/actor/mod.rs
+++ b/odorobo-agent/src/actor/mod.rs
@@ -7,7 +7,6 @@ use odorobo_shared::{
     messages::{Ping, Pong, debug::PanicAgent, vm::*},
     utils::vm_actor_id,
 };
-use rtnetlink::packet_route::route::RouteMessage;
 use serde::{Deserialize, Serialize};
 use stable_eyre::{Report, Result};
 use std::ops::ControlFlow;

--- a/odorobo-agent/src/actor/mod.rs
+++ b/odorobo-agent/src/actor/mod.rs
@@ -7,6 +7,7 @@ use odorobo_shared::{
     messages::{Ping, Pong, debug::PanicAgent, vm::*},
     utils::vm_actor_id,
 };
+use rtnetlink::packet_route::route::RouteMessage;
 use serde::{Deserialize, Serialize};
 use stable_eyre::{Report, Result};
 use std::ops::ControlFlow;
@@ -58,9 +59,19 @@ fn default_subnet() -> Ipv4Net {
 fn default_gateway() -> Ipv4Addr {
     "10.0.0.1".parse().unwrap()
 }
-
+/// Infers the default upstream interface from the system's default route
 fn default_upstream_iface() -> String {
-    "eth0".into()
+    // ip route
+    let out = std::process::Command::new("ip")
+        .arg("route")
+        .output()
+        .unwrap();
+    let output = String::from_utf8(out.stdout).unwrap();
+
+    let default_route = output.lines().find(|l| l.starts_with("default")).unwrap();
+    let iface = default_route.split_whitespace().nth(4).unwrap();
+    info!("inferring default upstream interface: {}", iface);
+    iface.into()
 }
 
 /// DHCP server config
@@ -71,7 +82,6 @@ fn default_upstream_iface() -> String {
 // --no-daemon
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct DhcpConfig {
-    pub upstream_iface: String,
     pub range: (Ipv4Addr, Ipv4Addr),
     pub subnet: Ipv4Net,
     /// lease time for DHCP clients
@@ -131,7 +141,7 @@ impl Default for NetworkMode {
 
 // The infra team wants a config file on the box where they can set info specific for the box its on.
 // TODO: Double check with infra team (katherine) if they want any other config on the box.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Default)]
 pub struct Config {
     /// The hostname of the agent. Defaults to the system hostname
     /// if not specified in the config file.
@@ -389,4 +399,29 @@ impl Message<PanicAgent> for AgentActor {
 }
 
 #[cfg(test)]
-mod tests {}
+mod tests {
+    use super::*;
+    #[test]
+    fn test_config_serialize() {
+        let config = Config {
+            network: NetworkConfig {
+                dhcp_config: Some(DhcpConfig {
+                    range: (Ipv4Addr::new(10, 10, 1, 100), Ipv4Addr::new(10, 10, 1, 200)),
+                    subnet: Ipv4Net::new(Ipv4Addr::new(10, 10, 1, 0), 24).unwrap(),
+                    lease_time: "12h".to_string(),
+                }),
+                network_mode: NetworkMode::HostonlyNat {
+                    bridge: "vmbr0".to_string(),
+                    gateway: Ipv4Addr::new(10, 10, 100, 1),
+                    subnet: Ipv4Net::new(Ipv4Addr::new(10, 10, 100, 0), 24).unwrap(),
+                    upstream_iface: default_upstream_iface(),
+                },
+            },
+            ..Default::default()
+        };
+
+        let json = serde_json::to_string_pretty(&config).unwrap();
+        // assert_eq!(json, )
+        println!("{}", json);
+    }
+}

--- a/odorobo-agent/src/lib.rs
+++ b/odorobo-agent/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod actor;
 mod api;
+pub mod networking;
 pub mod state;
 mod util;

--- a/odorobo-agent/src/main.rs
+++ b/odorobo-agent/src/main.rs
@@ -1,5 +1,6 @@
 pub mod actor;
 mod api;
+pub mod networking;
 mod state;
 mod util;
 use kameo::actor::Spawn;

--- a/odorobo-agent/src/networking/actor.rs
+++ b/odorobo-agent/src/networking/actor.rs
@@ -3,6 +3,7 @@ use crate::networking::messages::{AttachTap, DetachTap};
 use futures_util::{StreamExt, TryStreamExt};
 
 use kameo::{message::Context, prelude::*};
+use nftnl::{Batch, FinalizedBatch, Hook, MsgType, ProtoFamily, Rule, Table, nft_expr};
 use rtnetlink::{Error as NetlinkError, Handle, LinkBridge, LinkUnspec};
 use stable_eyre::Report;
 use stable_eyre::eyre::{Context as EyreContext, eyre};
@@ -21,6 +22,7 @@ impl Actor for DhcpActor {
     type Args = DhcpConfig;
     type Error = Report;
     async fn on_start(args: Self::Args, _actor_ref: ActorRef<Self>) -> Result<Self, Self::Error> {
+        // todo: actually run dnsmasq on startup
         Ok(Self { config: args })
     }
 }
@@ -82,6 +84,7 @@ async fn ensure_address(
         }),
     }
 }
+
 #[derive(RemoteActor)]
 pub struct NetworkAgentActor {
     pub config: NetworkConfig,
@@ -90,6 +93,7 @@ pub struct NetworkAgentActor {
     // netlink_handle:
     netlink_thread: tokio::task::JoinHandle<()>,
     netlink_handle: Handle,
+    nft_socket: mnl::Socket,
 }
 
 impl NetworkAgentActor {
@@ -107,6 +111,65 @@ impl NetworkAgentActor {
             .ok_or_else(|| eyre!("link {} not found", link_name))?
             .wrap_err_with(|| format!("failed to query link {}", link_name))
     }
+
+    fn send_nft_batch(&mut self, batch: &FinalizedBatch) -> Result<(), Report> {
+        let portid = self.nft_socket.portid();
+
+        self.nft_socket
+            .send_all(batch)
+            .wrap_err("failed to send nftables batch to netfilter")?;
+
+        let mut buffer = vec![0; nftnl::nft_nlmsg_maxsize() as usize];
+        let mut expected_seqs = batch.sequence_numbers();
+
+        while !expected_seqs.is_empty() {
+            for message in self
+                .nft_socket
+                .recv(&mut buffer[..])
+                .wrap_err("failed to receive nftables netlink acknowledgement")?
+            {
+                let message = message.wrap_err("failed to decode nft ack message")?;
+                let expected_seq = expected_seqs
+                    .next()
+                    .ok_or_else(|| eyre!("received unexpected nftables acknowledgement"))?;
+
+                mnl::cb_run(message, expected_seq, portid)
+                    .wrap_err("nftables batch acknowledgement failed")?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn ensure_nat_rules(
+        &mut self,
+        _bridge: &str,
+        _subnet: &str,
+        upstream_iface: &str,
+    ) -> Result<(), Report> {
+        let table = Table::new(c"nat", ProtoFamily::Ipv4);
+
+        let mut postrouting_chain = nftnl::Chain::new(c"postrouting", &table);
+        postrouting_chain.set_type(nftnl::ChainType::Nat);
+        postrouting_chain.set_hook(Hook::PostRouting, 100);
+
+        let mut batch = Batch::new();
+        batch.add(&table, MsgType::Add);
+        batch.add(&postrouting_chain, MsgType::Add);
+
+        let mut postrouting_rule = Rule::new(&postrouting_chain);
+        postrouting_rule.add_expr(&nft_expr!(meta oifname));
+        postrouting_rule.add_expr(&nft_expr!(cmp == upstream_iface));
+        postrouting_rule.add_expr(&nft_expr!(masquerade));
+        batch.add(&postrouting_rule, MsgType::Add);
+
+        let finalized = batch.finalize();
+        self.send_nft_batch(&finalized).wrap_err_with(|| {
+            format!("failed to apply nftables postrouting masquerade for {upstream_iface}")
+        })?;
+
+        Ok(())
+    }
 }
 
 impl Actor for NetworkAgentActor {
@@ -117,6 +180,8 @@ impl Actor for NetworkAgentActor {
 
         let (connection, handle, _) = rtnetlink::new_connection()?;
         let netlink_thread = tokio::spawn(connection);
+        let nft_socket = mnl::Socket::new(mnl::Bus::Netfilter)
+            .wrap_err("failed to create netfilter netlink socket")?;
 
         let common = match args.network_mode.clone() {
             NetworkMode::HostonlyNat {
@@ -168,22 +233,32 @@ impl Actor for NetworkAgentActor {
                 })?
         };
 
-        match args.network_mode.clone() {
+        let dhcp_actor = if let Some(dhcp_config) = &args.dhcp_config {
+            Some(DhcpActor::spawn_link(&actor_ref, dhcp_config.clone()).await)
+        } else {
+            None
+        };
+
+        let mut actor = Self {
+            config: args,
+            common,
+            dhcp_actor,
+            netlink_thread,
+            netlink_handle: handle,
+            nft_socket,
+        };
+
+        match actor.config.network_mode.clone() {
             NetworkMode::HostonlyNat {
                 bridge: _,
                 subnet,
                 gateway,
-                upstream_iface: _,
-            }
-            | NetworkMode::Bridged {
-                bridge: _,
-                subnet,
-                gateway,
+                upstream_iface,
             } => {
                 ensure_address(
-                    &handle,
+                    &actor.netlink_handle,
                     bridge.header.index,
-                    &common.bridge,
+                    &actor.common.bridge,
                     gateway,
                     subnet.prefix_len(),
                 )
@@ -193,27 +268,44 @@ impl Actor for NetworkAgentActor {
                         "failed to ensure gateway {}/{} exists on bridge {}",
                         gateway,
                         subnet.prefix_len(),
-                        common.bridge
+                        actor.common.bridge
+                    )
+                })?;
+
+                actor
+                    .ensure_nat_rules(&actor.common.bridge, &actor.common.subnet, &upstream_iface)
+                    .wrap_err_with(|| {
+                        format!(
+                            "failed to ensure nftables NAT rules for bridge {} and upstream {}",
+                            actor.common.bridge, upstream_iface
+                        )
+                    })?;
+            }
+            NetworkMode::Bridged {
+                bridge: _,
+                subnet,
+                gateway,
+            } => {
+                ensure_address(
+                    &actor.netlink_handle,
+                    bridge.header.index,
+                    &actor.common.bridge,
+                    gateway,
+                    subnet.prefix_len(),
+                )
+                .await
+                .wrap_err_with(|| {
+                    format!(
+                        "failed to ensure gateway {}/{} exists on bridge {}",
+                        gateway,
+                        subnet.prefix_len(),
+                        actor.common.bridge
                     )
                 })?;
             }
         }
 
-        // let link_bridge = LinkBridge::new(arg)
-
-        let dhcp_actor = if let Some(dhcp_config) = &args.dhcp_config {
-            Some(DhcpActor::spawn_link(&actor_ref, dhcp_config.clone()).await)
-        } else {
-            None
-        };
-
-        Ok(Self {
-            config: args,
-            common,
-            dhcp_actor,
-            netlink_thread,
-            netlink_handle: handle,
-        })
+        Ok(actor)
     }
 
     async fn on_stop(

--- a/odorobo-agent/src/networking/actor.rs
+++ b/odorobo-agent/src/networking/actor.rs
@@ -254,7 +254,6 @@ impl NetworkAgentActor {
     /// NAT/NAT66 policy as well. That is a larger design decision than this
     /// hook should make on its own. Until odorobo has an intentional IPv6
     /// guest-networking story, we keep host-only NAT scoped to IPv4.
-
     fn ensure_nat_rules(_bridge: &str, _subnet: &str, upstream_iface: &str) -> Result<(), Report> {
         const TABLE_NAME: &str = "odorobo";
         const CHAIN_NAME: &str = "guest_nat";

--- a/odorobo-agent/src/networking/actor.rs
+++ b/odorobo-agent/src/networking/actor.rs
@@ -3,14 +3,17 @@ use crate::networking::messages::{AttachTap, DetachTap};
 use futures_util::{StreamExt, TryStreamExt};
 
 use kameo::{message::Context, prelude::*};
-use nftnl::{
-    Batch, FinalizedBatch, Hook, MsgType, ProtoFamily, Rule, Table, expr::InterfaceName, nft_expr,
+use nftables::{
+    batch::Batch as NftBatch,
+    expr::{Expression, Meta, MetaKey, NamedExpression},
+    helper::{apply_ruleset, get_current_ruleset},
+    schema::{Chain as NftChain, NfListObject, NfObject, Rule as NftRule, Table as NftTable},
+    stmt::{Match as NftMatch, Operator, Statement},
+    types::{NfChainPolicy, NfChainType, NfFamily, NfHook},
 };
 use rtnetlink::{Error as NetlinkError, Handle, LinkBridge, LinkUnspec};
 use stable_eyre::Report;
 use stable_eyre::eyre::{Context as EyreContext, eyre};
-use std::ffi::CString;
-use std::process::Command;
 use tracing::info;
 
 pub struct DhcpActor {
@@ -165,75 +168,50 @@ impl NetworkAgentActor {
             .wrap_err_with(|| format!("failed to query link {}", link_name))
     }
 
-    fn send_nft_batch(batch: &FinalizedBatch) -> Result<(), Report> {
-        let socket = mnl::Socket::new(mnl::Bus::Netfilter)
-            .wrap_err("failed to create netfilter netlink socket")?;
-        let portid = socket.portid();
-
-        info!("sending nftables batch to netfilter");
-
-        socket
-            .send_all(batch)
-            .wrap_err("failed to send nftables batch to netfilter")?;
-
-        let mut buffer = vec![0; nftnl::nft_nlmsg_maxsize() as usize];
-        let mut expected_seqs = batch.sequence_numbers();
-
-        while !expected_seqs.is_empty() {
-            for message in socket
-                .recv(&mut buffer[..])
-                .wrap_err("failed to receive nftables netlink acknowledgement")?
-            {
-                let message = message.wrap_err("failed to decode nft ack message")?;
-                let expected_seq = expected_seqs
-                    .next()
-                    .ok_or_else(|| eyre!("received unexpected nftables acknowledgement"))?;
-
-                mnl::cb_run(message, expected_seq, portid)
-                    .wrap_err("nftables batch acknowledgement failed")?;
+    fn nft_table_exists(objects: &[NfObject<'_>], table: &str) -> bool {
+        objects.iter().any(|object| match object {
+            NfObject::ListObject(NfListObject::Table(existing)) => {
+                existing.family == NfFamily::IP && existing.name.as_ref() == table
             }
-        }
-
-        Ok(())
+            _ => false,
+        })
     }
 
-    // use the nft CLI instead because doing full introspection is kind of a pain
-    fn nft_table_exists(table: &str) -> Result<bool, Report> {
-        let output = Command::new("nft")
-            .args(["list", "table", "ip", table])
-            .output()
-            .wrap_err_with(|| format!("failed to query nft table ip {table}"))?;
-
-        Ok(output.status.success())
-    }
-
-    fn nft_chain_exists(table: &str, chain: &str) -> Result<bool, Report> {
-        let output = Command::new("nft")
-            .args(["list", "chain", "ip", table, chain])
-            .output()
-            .wrap_err_with(|| format!("failed to query nft chain ip {table} {chain}"))?;
-
-        Ok(output.status.success())
+    fn nft_chain_exists(objects: &[NfObject<'_>], table: &str, chain: &str) -> bool {
+        objects.iter().any(|object| match object {
+            NfObject::ListObject(NfListObject::Chain(existing)) => {
+                existing.family == NfFamily::IP
+                    && existing.table.as_ref() == table
+                    && existing.name.as_ref() == chain
+            }
+            _ => false,
+        })
     }
 
     fn nft_postrouting_masquerade_exists(
+        objects: &[NfObject<'_>],
         table: &str,
         chain: &str,
         upstream_iface: &str,
-    ) -> Result<bool, Report> {
-        let output = Command::new("nft")
-            .args(["list", "chain", "ip", table, chain])
-            .output()
-            .wrap_err_with(|| format!("failed to inspect nft chain ip {table} {chain}"))?;
-
-        if !output.status.success() {
-            return Ok(false);
-        }
-
-        let stdout = String::from_utf8(output.stdout)
-            .wrap_err_with(|| format!("failed to decode nft output for ip {table} {chain}"))?;
-
-        Ok(stdout.contains(&format!("oifname \"{upstream_iface}\" masquerade")))
+    ) -> bool {
+        objects.iter().any(|object| match object {
+            NfObject::ListObject(NfListObject::Rule(existing)) => {
+                existing.family == NfFamily::IP
+                    && existing.table.as_ref() == table
+                    && existing.chain.as_ref() == chain
+                    && matches!(
+                        existing.expr.as_ref(),
+                        [Statement::Match(NftMatch { left, right, op }), Statement::Masquerade(_)]
+                            if *op == Operator::EQ
+                                && matches!(
+                                    left,
+                                    Expression::Named(NamedExpression::Meta(Meta { key: MetaKey::Oifname }))
+                                )
+                                && matches!(right, Expression::String(iface) if iface.as_ref() == upstream_iface)
+                    )
+            }
+            _ => false,
+        })
     }
 
     /// Ensures the host-only NAT masquerade rule exists for the configured
@@ -289,16 +267,19 @@ impl NetworkAgentActor {
             "ensuring host-only NAT masquerade rule exists"
         );
 
-        let table_exists = Self::nft_table_exists(TABLE_NAME)?;
-        let chain_exists = if table_exists {
-            Self::nft_chain_exists(TABLE_NAME, CHAIN_NAME)?
-        } else {
-            false
-        };
+        let ruleset = get_current_ruleset().wrap_err("failed to fetch current nftables ruleset")?;
+        let objects = ruleset.objects.as_ref();
 
-        if chain_exists
-            && Self::nft_postrouting_masquerade_exists(TABLE_NAME, CHAIN_NAME, upstream_iface)?
-        {
+        let table_exists = Self::nft_table_exists(objects, TABLE_NAME);
+        let chain_exists = Self::nft_chain_exists(objects, TABLE_NAME, CHAIN_NAME);
+        let rule_exists = Self::nft_postrouting_masquerade_exists(
+            objects,
+            TABLE_NAME,
+            CHAIN_NAME,
+            upstream_iface,
+        );
+
+        if rule_exists {
             info!(
                 table = TABLE_NAME,
                 chain = CHAIN_NAME,
@@ -308,39 +289,62 @@ impl NetworkAgentActor {
             return Ok(());
         }
 
-        let table = Table::new(c"odorobo", ProtoFamily::Ipv4);
+        let mut batch = NftBatch::new();
 
-        let mut postrouting_chain = nftnl::Chain::new(c"guest_nat", &table);
-        postrouting_chain.set_type(nftnl::ChainType::Nat);
-        postrouting_chain.set_hook(Hook::PostRouting, 100);
-
-        let mut batch = Batch::new();
         if !table_exists {
             info!(table = TABLE_NAME, "creating odorobo nftables table");
-            batch.add(&table, MsgType::Add);
+            batch.add(NfListObject::Table(NftTable {
+                family: NfFamily::IP,
+                name: TABLE_NAME.into(),
+                handle: None,
+            }));
         }
+
         if !chain_exists {
             info!(
                 table = TABLE_NAME,
                 chain = CHAIN_NAME,
                 "creating odorobo nftables chain"
             );
-            batch.add(&postrouting_chain, MsgType::Add);
+            batch.add(NfListObject::Chain(NftChain {
+                family: NfFamily::IP,
+                table: TABLE_NAME.into(),
+                name: CHAIN_NAME.into(),
+                newname: None,
+                handle: None,
+                _type: Some(NfChainType::NAT),
+                hook: Some(NfHook::Postrouting),
+                prio: Some(100),
+                dev: None,
+                policy: Some(NfChainPolicy::Accept),
+            }));
         }
 
-        let mut postrouting_rule = Rule::new(&postrouting_chain);
-        let upstream_iface = InterfaceName::Exact(
-            CString::new(upstream_iface)
-                .wrap_err("upstream interface name contained interior NUL")?,
-        );
-        postrouting_rule.add_expr(&nft_expr!(meta oifname));
-        postrouting_rule.add_expr(&nft_expr!(cmp == &upstream_iface));
-        postrouting_rule.add_expr(&nft_expr!(masquerade));
-        batch.add(&postrouting_rule, MsgType::Add);
+        batch.add(NfListObject::Rule(NftRule {
+            family: NfFamily::IP,
+            table: TABLE_NAME.into(),
+            chain: CHAIN_NAME.into(),
+            expr: vec![
+                Statement::Match(NftMatch {
+                    left: Expression::Named(NamedExpression::Meta(Meta {
+                        key: MetaKey::Oifname,
+                    })),
+                    right: Expression::String(upstream_iface.into()),
+                    op: Operator::EQ,
+                }),
+                Statement::Masquerade(None),
+            ]
+            .into(),
+            handle: None,
+            index: None,
+            comment: Some("odorobo host-only NAT".into()),
+        }));
 
-        let finalized = batch.finalize();
-        Self::send_nft_batch(&finalized).wrap_err_with(|| {
-            format!("failed to apply nftables postrouting masquerade for {upstream_iface:?}")
+        let batch = batch.to_nftables();
+        apply_ruleset(&batch).wrap_err_with(|| {
+            format!(
+                "failed to apply nftables postrouting masquerade for upstream interface {upstream_iface}"
+            )
         })?;
 
         Ok(())

--- a/odorobo-agent/src/networking/actor.rs
+++ b/odorobo-agent/src/networking/actor.rs
@@ -214,23 +214,6 @@ impl NetworkAgentActor {
         })
     }
 
-    /// Ensures the host-only NAT masquerade rule exists for the configured
-    /// upstream interface.
-    ///
-    /// This is intentionally IPv4-only for now.
-    ///
-    /// The current host-only networking model is built around IPv4 guest
-    /// addressing and an IPv4 bridge gateway:
-    /// - guest subnet config uses `Ipv4Net`
-    /// - bridge gateway config uses `Ipv4Addr`
-    /// - bridge address assignment is currently IPv4-only
-    ///
-    /// Although nftables can match by interface in `inet` tables, switching
-    /// this masquerade rule to dual-stack would implicitly opt us into IPv6
-    /// NAT/NAT66 policy as well. That is a larger design decision than this
-    /// hook should make on its own. Until odorobo has an intentional IPv6
-    /// guest-networking story, we keep host-only NAT scoped to IPv4.
-    ///
     // todo: IPv6, refer to libvirt's impl:
     // ```nft
     // table ip6 libvirt_network {
@@ -255,6 +238,23 @@ impl NetworkAgentActor {
     //         }
     // }
     // ```
+    /// Ensures the host-only NAT masquerade rule exists for the configured
+    /// upstream interface.
+    ///
+    /// This is intentionally IPv4-only for now.
+    ///
+    /// The current host-only networking model is built around IPv4 guest
+    /// addressing and an IPv4 bridge gateway:
+    /// - guest subnet config uses `Ipv4Net`
+    /// - bridge gateway config uses `Ipv4Addr`
+    /// - bridge address assignment is currently IPv4-only
+    ///
+    /// Although nftables can match by interface in `inet` tables, switching
+    /// this masquerade rule to dual-stack would implicitly opt us into IPv6
+    /// NAT/NAT66 policy as well. That is a larger design decision than this
+    /// hook should make on its own. Until odorobo has an intentional IPv6
+    /// guest-networking story, we keep host-only NAT scoped to IPv4.
+    ///
 
     fn ensure_nat_rules(_bridge: &str, _subnet: &str, upstream_iface: &str) -> Result<(), Report> {
         const TABLE_NAME: &str = "odorobo";
@@ -393,7 +393,7 @@ impl Actor for NetworkAgentActor {
 
         let bridge = match bridge_lookup {
             Some(Ok(bridge)) => bridge,
-            Some(Err(err)) if matches!(err, NetlinkError::NetlinkError(ref nl_err) if nl_err.raw_code() == -libc::ENODEV) =>
+            Some(Err(NetlinkError::NetlinkError(ref nl_err))) if nl_err.raw_code() == -libc::ENODEV =>
             {
                 info!(bridge = %common.bridge, "bridge not found during lookup, creating it");
                 let new_bridge = LinkBridge::new(&common.bridge).up().build();

--- a/odorobo-agent/src/networking/actor.rs
+++ b/odorobo-agent/src/networking/actor.rs
@@ -200,9 +200,36 @@ impl NetworkAgentActor {
     /// NAT/NAT66 policy as well. That is a larger design decision than this
     /// hook should make on its own. Until odorobo has an intentional IPv6
     /// guest-networking story, we keep host-only NAT scoped to IPv4.
+    /// 
+    // todo: IPv6, refer to libvirt's impl:
+    // ```nft
+    // table ip6 libvirt_network {
+    //         chain forward {
+    //                 type filter hook forward priority filter; policy accept;
+    //                 counter packets 0 bytes 0 jump guest_cross
+    //                 counter packets 0 bytes 0 jump guest_input
+    //                 counter packets 0 bytes 0 jump guest_output
+    //         }
+    
+    //         chain guest_output {
+    //         }
+    
+    //         chain guest_input {
+    //         }
+    
+    //         chain guest_cross {
+    //         }
+    
+    //         chain guest_nat {
+    //                 type nat hook postrouting priority srcnat; policy accept;
+    //         }
+    // }
+    // ```
+    
+
     fn ensure_nat_rules(_bridge: &str, _subnet: &str, upstream_iface: &str) -> Result<(), Report> {
         const TABLE_NAME: &str = "odorobo";
-        const CHAIN_NAME: &str = "postrouting";
+        const CHAIN_NAME: &str = "guest_nat";
 
         let table_exists = Self::nft_table_exists(TABLE_NAME)?;
         let chain_exists = if table_exists {
@@ -219,7 +246,7 @@ impl NetworkAgentActor {
 
         let table = Table::new(c"odorobo", ProtoFamily::Ipv4);
 
-        let mut postrouting_chain = nftnl::Chain::new(c"postrouting", &table);
+        let mut postrouting_chain = nftnl::Chain::new(c"guest_nat", &table);
         postrouting_chain.set_type(nftnl::ChainType::Nat);
         postrouting_chain.set_hook(Hook::PostRouting, 100);
 

--- a/odorobo-agent/src/networking/actor.rs
+++ b/odorobo-agent/src/networking/actor.rs
@@ -1,0 +1,366 @@
+use crate::actor::{DhcpConfig, NetworkConfig, NetworkMode};
+use crate::networking::messages::{AttachTap, DetachTap};
+use futures_util::{StreamExt, TryStreamExt};
+
+use kameo::{message::Context, prelude::*};
+use rtnetlink::{Error as NetlinkError, Handle, LinkBridge, LinkUnspec};
+use stable_eyre::Report;
+use stable_eyre::eyre::{Context as EyreContext, eyre};
+use tracing::info;
+
+pub struct DhcpActor {
+    pub config: DhcpConfig,
+}
+
+pub struct NetworkConfigCommon {
+    pub bridge: String,
+    pub subnet: String,
+}
+
+impl Actor for DhcpActor {
+    type Args = DhcpConfig;
+    type Error = Report;
+    async fn on_start(args: Self::Args, _actor_ref: ActorRef<Self>) -> Result<Self, Self::Error> {
+        Ok(Self { config: args })
+    }
+}
+
+async fn ensure_address(
+    handle: &Handle,
+    link_index: u32,
+    link_name: &str,
+    address: std::net::Ipv4Addr,
+    prefix_len: u8,
+) -> Result<(), Report> {
+    let mut existing = handle
+        .address()
+        .get()
+        .set_link_index_filter(link_index)
+        .execute();
+
+    while let Some(address_msg) = existing.try_next().await? {
+        if address_msg.header.prefix_len != prefix_len {
+            continue;
+        }
+
+        let already_present = address_msg.attributes.iter().any(|attr| match attr {
+            rtnetlink::packet_route::address::AddressAttribute::Address(ip)
+            | rtnetlink::packet_route::address::AddressAttribute::Local(ip) => {
+                matches!(ip, std::net::IpAddr::V4(existing_ip) if *existing_ip == address)
+            }
+            _ => false,
+        });
+
+        if already_present {
+            info!(
+                bridge = link_name,
+                address = %address,
+                prefix_len,
+                "bridge gateway address already present"
+            );
+            return Ok(());
+        }
+    }
+
+    info!(
+        bridge = link_name,
+        address = %address,
+        prefix_len,
+        "adding gateway address to bridge"
+    );
+
+    match handle
+        .address()
+        .add(link_index, address.into(), prefix_len)
+        .execute()
+        .await
+    {
+        Ok(()) => Ok(()),
+        Err(NetlinkError::NetlinkError(err)) if err.raw_code() == -libc::EEXIST => Ok(()),
+        Err(err) => Err(err).wrap_err_with(|| {
+            format!("failed to add address {address}/{prefix_len} to {link_name}")
+        }),
+    }
+}
+#[derive(RemoteActor)]
+pub struct NetworkAgentActor {
+    pub config: NetworkConfig,
+    common: NetworkConfigCommon,
+    pub dhcp_actor: Option<ActorRef<DhcpActor>>,
+    // netlink_handle:
+    netlink_thread: tokio::task::JoinHandle<()>,
+    netlink_handle: Handle,
+}
+
+impl NetworkAgentActor {
+    async fn lookup_link_by_name(
+        &self,
+        link_name: &str,
+    ) -> Result<rtnetlink::packet_route::link::LinkMessage, Report> {
+        self.netlink_handle
+            .link()
+            .get()
+            .match_name(link_name.to_string())
+            .execute()
+            .next()
+            .await
+            .ok_or_else(|| eyre!("link {} not found", link_name))?
+            .wrap_err_with(|| format!("failed to query link {}", link_name))
+    }
+}
+
+impl Actor for NetworkAgentActor {
+    type Args = NetworkConfig;
+    type Error = Report;
+    async fn on_start(args: Self::Args, actor_ref: ActorRef<Self>) -> Result<Self, Self::Error> {
+        // do some netlink fuckery here
+
+        let (connection, handle, _) = rtnetlink::new_connection()?;
+        let netlink_thread = tokio::spawn(connection);
+
+        let common = match args.network_mode.clone() {
+            NetworkMode::HostonlyNat {
+                bridge,
+                subnet,
+                gateway: _,
+                upstream_iface: _,
+            }
+            | NetworkMode::Bridged {
+                bridge,
+                subnet,
+                gateway: _,
+            } => NetworkConfigCommon {
+                bridge,
+                subnet: subnet.to_string(),
+            },
+        };
+
+        // ensure the bridge exists, creating it if necessary
+        let bridge = if let Some(bridge) = handle
+            .link()
+            .get()
+            .match_name(common.bridge.clone())
+            .execute()
+            .next()
+            .await
+        {
+            bridge.wrap_err_with(|| format!("failed to query bridge {}", common.bridge))?
+        } else {
+            info!(bridge = %common.bridge, "creating new bridge");
+            let new_bridge = LinkBridge::new(&common.bridge).up().build();
+            handle
+                .link()
+                .add(new_bridge)
+                .execute()
+                .await
+                .wrap_err_with(|| format!("failed to create bridge {}", common.bridge))?;
+
+            handle
+                .link()
+                .get()
+                .match_name(common.bridge.clone())
+                .execute()
+                .next()
+                .await
+                .ok_or_else(|| eyre!("bridge {} was not found after creation", common.bridge))?
+                .wrap_err_with(|| {
+                    format!("failed to query bridge {} after creation", common.bridge)
+                })?
+        };
+
+        match args.network_mode.clone() {
+            NetworkMode::HostonlyNat {
+                bridge: _,
+                subnet,
+                gateway,
+                upstream_iface: _,
+            }
+            | NetworkMode::Bridged {
+                bridge: _,
+                subnet,
+                gateway,
+            } => {
+                ensure_address(
+                    &handle,
+                    bridge.header.index,
+                    &common.bridge,
+                    gateway,
+                    subnet.prefix_len(),
+                )
+                .await
+                .wrap_err_with(|| {
+                    format!(
+                        "failed to ensure gateway {}/{} exists on bridge {}",
+                        gateway,
+                        subnet.prefix_len(),
+                        common.bridge
+                    )
+                })?;
+            }
+        }
+
+        // let link_bridge = LinkBridge::new(arg)
+
+        let dhcp_actor = if let Some(dhcp_config) = &args.dhcp_config {
+            Some(DhcpActor::spawn_link(&actor_ref, dhcp_config.clone()).await)
+        } else {
+            None
+        };
+
+        Ok(Self {
+            config: args,
+            common,
+            dhcp_actor,
+            netlink_thread,
+            netlink_handle: handle,
+        })
+    }
+
+    async fn on_stop(
+        &mut self,
+        _actor_ref: WeakActorRef<Self>,
+        reason: ActorStopReason,
+    ) -> std::result::Result<(), Self::Error> {
+        match reason {
+            ActorStopReason::Normal => {
+                info!(bridge = %self.common.bridge, "stopping network agent");
+            }
+            ActorStopReason::Killed => {
+                info!(bridge = %self.common.bridge, "network agent killed");
+            }
+            ActorStopReason::Panicked(err) => {
+                info!(bridge = %self.common.bridge, ?err, "network agent panicked");
+            }
+            _ => {
+                info!(bridge = %self.common.bridge, "network agent stopping");
+            }
+        }
+
+        if let Some(dhcp_actor) = self.dhcp_actor.take() {
+            dhcp_actor.stop_gracefully().await?;
+        }
+
+        self.netlink_thread.abort();
+        let _ = (&mut self.netlink_thread).await;
+
+        Ok(())
+    }
+}
+
+impl Message<AttachTap> for NetworkAgentActor {
+    type Reply = Result<(), Report>;
+
+    async fn handle(
+        &mut self,
+        msg: AttachTap,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let bridge = self
+            .lookup_link_by_name(&self.common.bridge)
+            .await
+            .wrap_err_with(|| {
+                format!(
+                    "failed to resolve bridge {} before attaching tap {}",
+                    self.common.bridge, msg.tap_name
+                )
+            })?;
+
+        let tap = self
+            .lookup_link_by_name(&msg.tap_name)
+            .await
+            .wrap_err_with(|| {
+                format!("failed to resolve tap {} for vm {}", msg.tap_name, msg.vmid)
+            })?;
+
+        info!(
+            vmid = %msg.vmid,
+            tap = %msg.tap_name,
+            bridge = %self.common.bridge,
+            "attaching tap to bridge"
+        );
+
+        self.netlink_handle
+            .link()
+            .set(
+                LinkUnspec::new_with_index(tap.header.index)
+                    .controller(bridge.header.index)
+                    .build(),
+            )
+            .execute()
+            .await
+            .wrap_err_with(|| {
+                format!(
+                    "failed to attach tap {} to bridge {}",
+                    msg.tap_name, self.common.bridge
+                )
+            })?;
+
+        self.netlink_handle
+            .link()
+            .set(LinkUnspec::new_with_index(tap.header.index).up().build())
+            .execute()
+            .await
+            .wrap_err_with(|| format!("failed to bring tap {} up", msg.tap_name))?;
+
+        info!(
+            vmid = %msg.vmid,
+            tap = %msg.tap_name,
+            bridge = %self.common.bridge,
+            "tap attached to bridge successfully"
+        );
+
+        Ok(())
+    }
+}
+
+impl Message<DetachTap> for NetworkAgentActor {
+    type Reply = Result<(), Report>;
+
+    async fn handle(
+        &mut self,
+        msg: DetachTap,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let tap = self
+            .lookup_link_by_name(&msg.tap_name)
+            .await
+            .wrap_err_with(|| {
+                format!(
+                    "failed to resolve tap {} for detach on vm {}",
+                    msg.tap_name, msg.vmid
+                )
+            })?;
+
+        info!(
+            vmid = %msg.vmid,
+            tap = %msg.tap_name,
+            bridge = %self.common.bridge,
+            "detaching tap from bridge"
+        );
+
+        self.netlink_handle
+            .link()
+            .set(
+                LinkUnspec::new_with_index(tap.header.index)
+                    .nocontroller()
+                    .build(),
+            )
+            .execute()
+            .await
+            .wrap_err_with(|| {
+                format!(
+                    "failed to detach tap {} from bridge {}",
+                    msg.tap_name, self.common.bridge
+                )
+            })?;
+
+        info!(
+            vmid = %msg.vmid,
+            tap = %msg.tap_name,
+            bridge = %self.common.bridge,
+            "tap detached from bridge successfully"
+        );
+
+        Ok(())
+    }
+}

--- a/odorobo-agent/src/networking/actor.rs
+++ b/odorobo-agent/src/networking/actor.rs
@@ -22,6 +22,7 @@ pub struct DhcpActor {
 pub struct NetworkConfigCommon {
     pub bridge: String,
     pub subnet: String,
+    pub upstream_iface: Option<String>,
 }
 
 impl Actor for DhcpActor {
@@ -35,6 +36,15 @@ impl Actor for DhcpActor {
             config.range.1,
             config.subnet.netmask(),
             config.lease_time
+        );
+
+        info!(
+            bridge = %bridge,
+            range_start = %config.range.0,
+            range_end = %config.range.1,
+            subnet = %config.subnet,
+            lease_time = %config.lease_time,
+            "starting dnsmasq for guest DHCP"
         );
 
         let dnsmasq_process = tokio::process::Command::new("dnsmasq")
@@ -160,6 +170,8 @@ impl NetworkAgentActor {
             .wrap_err("failed to create netfilter netlink socket")?;
         let portid = socket.portid();
 
+        info!("sending nftables batch to netfilter");
+
         socket
             .send_all(batch)
             .wrap_err("failed to send nftables batch to netfilter")?;
@@ -270,6 +282,13 @@ impl NetworkAgentActor {
         const TABLE_NAME: &str = "odorobo";
         const CHAIN_NAME: &str = "guest_nat";
 
+        info!(
+            table = TABLE_NAME,
+            chain = CHAIN_NAME,
+            upstream_iface = upstream_iface,
+            "ensuring host-only NAT masquerade rule exists"
+        );
+
         let table_exists = Self::nft_table_exists(TABLE_NAME)?;
         let chain_exists = if table_exists {
             Self::nft_chain_exists(TABLE_NAME, CHAIN_NAME)?
@@ -280,6 +299,12 @@ impl NetworkAgentActor {
         if chain_exists
             && Self::nft_postrouting_masquerade_exists(TABLE_NAME, CHAIN_NAME, upstream_iface)?
         {
+            info!(
+                table = TABLE_NAME,
+                chain = CHAIN_NAME,
+                upstream_iface = upstream_iface,
+                "existing NAT masquerade rule already present"
+            );
             return Ok(());
         }
 
@@ -291,9 +316,15 @@ impl NetworkAgentActor {
 
         let mut batch = Batch::new();
         if !table_exists {
+            info!(table = TABLE_NAME, "creating odorobo nftables table");
             batch.add(&table, MsgType::Add);
         }
         if !chain_exists {
+            info!(
+                table = TABLE_NAME,
+                chain = CHAIN_NAME,
+                "creating odorobo nftables chain"
+            );
             batch.add(&postrouting_chain, MsgType::Add);
         }
 
@@ -330,49 +361,83 @@ impl Actor for NetworkAgentActor {
                 bridge,
                 subnet,
                 gateway: _,
-                upstream_iface: _,
-            }
-            | NetworkMode::Bridged {
+                upstream_iface,
+            } => NetworkConfigCommon {
+                bridge,
+                subnet: subnet.to_string(),
+                upstream_iface: Some(upstream_iface),
+            },
+            NetworkMode::Bridged {
                 bridge,
                 subnet,
                 gateway: _,
             } => NetworkConfigCommon {
                 bridge,
                 subnet: subnet.to_string(),
+                upstream_iface: None,
             },
         };
 
         // ensure the bridge exists, creating it if necessary
-        let bridge = if let Some(bridge) = handle
+        let bridge_lookup = handle
             .link()
             .get()
             .match_name(common.bridge.clone())
             .execute()
             .next()
-            .await
-        {
-            bridge.wrap_err_with(|| format!("failed to query bridge {}", common.bridge))?
-        } else {
-            info!(bridge = %common.bridge, "creating new bridge");
-            let new_bridge = LinkBridge::new(&common.bridge).up().build();
-            handle
-                .link()
-                .add(new_bridge)
-                .execute()
-                .await
-                .wrap_err_with(|| format!("failed to create bridge {}", common.bridge))?;
+            .await;
 
-            handle
-                .link()
-                .get()
-                .match_name(common.bridge.clone())
-                .execute()
-                .next()
-                .await
-                .ok_or_else(|| eyre!("bridge {} was not found after creation", common.bridge))?
-                .wrap_err_with(|| {
-                    format!("failed to query bridge {} after creation", common.bridge)
-                })?
+        let bridge = match bridge_lookup {
+            Some(Ok(bridge)) => bridge,
+            Some(Err(err)) if matches!(err, NetlinkError::NetlinkError(ref nl_err) if nl_err.raw_code() == -libc::ENODEV) =>
+            {
+                info!(bridge = %common.bridge, "bridge not found during lookup, creating it");
+                let new_bridge = LinkBridge::new(&common.bridge).up().build();
+                handle
+                    .link()
+                    .add(new_bridge)
+                    .execute()
+                    .await
+                    .wrap_err_with(|| format!("failed to create bridge {}", common.bridge))?;
+
+                handle
+                    .link()
+                    .get()
+                    .match_name(common.bridge.clone())
+                    .execute()
+                    .next()
+                    .await
+                    .ok_or_else(|| eyre!("bridge {} was not found after creation", common.bridge))?
+                    .wrap_err_with(|| {
+                        format!("failed to query bridge {} after creation", common.bridge)
+                    })?
+            }
+            Some(Err(err)) => {
+                return Err(err)
+                    .wrap_err_with(|| format!("failed to query bridge {}", common.bridge));
+            }
+            None => {
+                info!(bridge = %common.bridge, "creating new bridge");
+                let new_bridge = LinkBridge::new(&common.bridge).up().build();
+                handle
+                    .link()
+                    .add(new_bridge)
+                    .execute()
+                    .await
+                    .wrap_err_with(|| format!("failed to create bridge {}", common.bridge))?;
+
+                handle
+                    .link()
+                    .get()
+                    .match_name(common.bridge.clone())
+                    .execute()
+                    .next()
+                    .await
+                    .ok_or_else(|| eyre!("bridge {} was not found after creation", common.bridge))?
+                    .wrap_err_with(|| {
+                        format!("failed to query bridge {} after creation", common.bridge)
+                    })?
+            }
         };
 
         let dhcp_actor = if let Some(dhcp_config) = &args.dhcp_config {
@@ -395,13 +460,27 @@ impl Actor for NetworkAgentActor {
         let common_bridge = actor.common.bridge.clone();
         let common_subnet = actor.common.subnet.clone();
 
+        info!(
+            bridge = %common_bridge,
+            subnet = %common_subnet,
+            upstream_iface = ?actor.common.upstream_iface,
+            "network actor startup configuration resolved"
+        );
+
         match actor.config.network_mode.clone() {
             NetworkMode::HostonlyNat {
                 bridge: _,
                 subnet,
                 gateway,
-                upstream_iface,
+                upstream_iface: _,
             } => {
+                info!(
+                    bridge = %actor.common.bridge,
+                    gateway = %gateway,
+                    prefix_len = subnet.prefix_len(),
+                    "ensuring host-only NAT bridge gateway address"
+                );
+
                 ensure_address(
                     &actor.netlink_handle,
                     bridge.header.index,
@@ -419,7 +498,18 @@ impl Actor for NetworkAgentActor {
                     )
                 })?;
 
-                Self::ensure_nat_rules(&common_bridge, &common_subnet, &upstream_iface)
+                let upstream_iface =
+                    actor.common.upstream_iface.as_deref().ok_or_else(|| {
+                        eyre!("host-only NAT mode requires an upstream interface")
+                    })?;
+
+                info!(
+                    bridge = %common_bridge,
+                    upstream_iface = upstream_iface,
+                    "host-only NAT uses routed upstream interface rather than bridge master"
+                );
+
+                Self::ensure_nat_rules(&common_bridge, &common_subnet, upstream_iface)
                     .wrap_err_with(|| {
                         format!(
                             "failed to ensure nftables NAT rules for bridge {} and upstream {}",
@@ -432,6 +522,13 @@ impl Actor for NetworkAgentActor {
                 subnet,
                 gateway,
             } => {
+                info!(
+                    bridge = %actor.common.bridge,
+                    gateway = %gateway,
+                    prefix_len = subnet.prefix_len(),
+                    "ensuring bridged mode host address on bridge"
+                );
+
                 ensure_address(
                     &actor.netlink_handle,
                     bridge.header.index,

--- a/odorobo-agent/src/networking/actor.rs
+++ b/odorobo-agent/src/networking/actor.rs
@@ -10,6 +10,7 @@ use rtnetlink::{Error as NetlinkError, Handle, LinkBridge, LinkUnspec};
 use stable_eyre::Report;
 use stable_eyre::eyre::{Context as EyreContext, eyre};
 use std::ffi::CString;
+use std::process::Command;
 use tracing::info;
 
 pub struct DhcpActor {
@@ -144,6 +145,45 @@ impl NetworkAgentActor {
         Ok(())
     }
 
+    // use the nft CLI instead because doing full introspection is kind of a pain
+    fn nft_table_exists(table: &str) -> Result<bool, Report> {
+        let output = Command::new("nft")
+            .args(["list", "table", "ip", table])
+            .output()
+            .wrap_err_with(|| format!("failed to query nft table ip {table}"))?;
+
+        Ok(output.status.success())
+    }
+
+    fn nft_chain_exists(table: &str, chain: &str) -> Result<bool, Report> {
+        let output = Command::new("nft")
+            .args(["list", "chain", "ip", table, chain])
+            .output()
+            .wrap_err_with(|| format!("failed to query nft chain ip {table} {chain}"))?;
+
+        Ok(output.status.success())
+    }
+
+    fn nft_postrouting_masquerade_exists(
+        table: &str,
+        chain: &str,
+        upstream_iface: &str,
+    ) -> Result<bool, Report> {
+        let output = Command::new("nft")
+            .args(["list", "chain", "ip", table, chain])
+            .output()
+            .wrap_err_with(|| format!("failed to inspect nft chain ip {table} {chain}"))?;
+
+        if !output.status.success() {
+            return Ok(false);
+        }
+
+        let stdout = String::from_utf8(output.stdout)
+            .wrap_err_with(|| format!("failed to decode nft output for ip {table} {chain}"))?;
+
+        Ok(stdout.contains(&format!("oifname \"{upstream_iface}\" masquerade")))
+    }
+
     /// Ensures the host-only NAT masquerade rule exists for the configured
     /// upstream interface.
     ///
@@ -161,15 +201,35 @@ impl NetworkAgentActor {
     /// hook should make on its own. Until odorobo has an intentional IPv6
     /// guest-networking story, we keep host-only NAT scoped to IPv4.
     fn ensure_nat_rules(_bridge: &str, _subnet: &str, upstream_iface: &str) -> Result<(), Report> {
-        let table = Table::new(c"nat", ProtoFamily::Ipv4);
+        const TABLE_NAME: &str = "odorobo";
+        const CHAIN_NAME: &str = "postrouting";
+
+        let table_exists = Self::nft_table_exists(TABLE_NAME)?;
+        let chain_exists = if table_exists {
+            Self::nft_chain_exists(TABLE_NAME, CHAIN_NAME)?
+        } else {
+            false
+        };
+
+        if chain_exists
+            && Self::nft_postrouting_masquerade_exists(TABLE_NAME, CHAIN_NAME, upstream_iface)?
+        {
+            return Ok(());
+        }
+
+        let table = Table::new(c"odorobo", ProtoFamily::Ipv4);
 
         let mut postrouting_chain = nftnl::Chain::new(c"postrouting", &table);
         postrouting_chain.set_type(nftnl::ChainType::Nat);
         postrouting_chain.set_hook(Hook::PostRouting, 100);
 
         let mut batch = Batch::new();
-        batch.add(&table, MsgType::Add);
-        batch.add(&postrouting_chain, MsgType::Add);
+        if !table_exists {
+            batch.add(&table, MsgType::Add);
+        }
+        if !chain_exists {
+            batch.add(&postrouting_chain, MsgType::Add);
+        }
 
         let mut postrouting_rule = Rule::new(&postrouting_chain);
         let upstream_iface = InterfaceName::Exact(

--- a/odorobo-agent/src/networking/actor.rs
+++ b/odorobo-agent/src/networking/actor.rs
@@ -254,7 +254,6 @@ impl NetworkAgentActor {
     /// NAT/NAT66 policy as well. That is a larger design decision than this
     /// hook should make on its own. Until odorobo has an intentional IPv6
     /// guest-networking story, we keep host-only NAT scoped to IPv4.
-    ///
 
     fn ensure_nat_rules(_bridge: &str, _subnet: &str, upstream_iface: &str) -> Result<(), Report> {
         const TABLE_NAME: &str = "odorobo";

--- a/odorobo-agent/src/networking/actor.rs
+++ b/odorobo-agent/src/networking/actor.rs
@@ -3,10 +3,13 @@ use crate::networking::messages::{AttachTap, DetachTap};
 use futures_util::{StreamExt, TryStreamExt};
 
 use kameo::{message::Context, prelude::*};
-use nftnl::{Batch, FinalizedBatch, Hook, MsgType, ProtoFamily, Rule, Table, nft_expr};
+use nftnl::{
+    Batch, FinalizedBatch, Hook, MsgType, ProtoFamily, Rule, Table, expr::InterfaceName, nft_expr,
+};
 use rtnetlink::{Error as NetlinkError, Handle, LinkBridge, LinkUnspec};
 use stable_eyre::Report;
 use stable_eyre::eyre::{Context as EyreContext, eyre};
+use std::ffi::CString;
 use tracing::info;
 
 pub struct DhcpActor {
@@ -93,7 +96,6 @@ pub struct NetworkAgentActor {
     // netlink_handle:
     netlink_thread: tokio::task::JoinHandle<()>,
     netlink_handle: Handle,
-    nft_socket: mnl::Socket,
 }
 
 impl NetworkAgentActor {
@@ -112,10 +114,12 @@ impl NetworkAgentActor {
             .wrap_err_with(|| format!("failed to query link {}", link_name))
     }
 
-    fn send_nft_batch(&mut self, batch: &FinalizedBatch) -> Result<(), Report> {
-        let portid = self.nft_socket.portid();
+    fn send_nft_batch(batch: &FinalizedBatch) -> Result<(), Report> {
+        let socket = mnl::Socket::new(mnl::Bus::Netfilter)
+            .wrap_err("failed to create netfilter netlink socket")?;
+        let portid = socket.portid();
 
-        self.nft_socket
+        socket
             .send_all(batch)
             .wrap_err("failed to send nftables batch to netfilter")?;
 
@@ -123,8 +127,7 @@ impl NetworkAgentActor {
         let mut expected_seqs = batch.sequence_numbers();
 
         while !expected_seqs.is_empty() {
-            for message in self
-                .nft_socket
+            for message in socket
                 .recv(&mut buffer[..])
                 .wrap_err("failed to receive nftables netlink acknowledgement")?
             {
@@ -141,12 +144,23 @@ impl NetworkAgentActor {
         Ok(())
     }
 
-    fn ensure_nat_rules(
-        &mut self,
-        _bridge: &str,
-        _subnet: &str,
-        upstream_iface: &str,
-    ) -> Result<(), Report> {
+    /// Ensures the host-only NAT masquerade rule exists for the configured
+    /// upstream interface.
+    ///
+    /// This is intentionally IPv4-only for now.
+    ///
+    /// The current host-only networking model is built around IPv4 guest
+    /// addressing and an IPv4 bridge gateway:
+    /// - guest subnet config uses `Ipv4Net`
+    /// - bridge gateway config uses `Ipv4Addr`
+    /// - bridge address assignment is currently IPv4-only
+    ///
+    /// Although nftables can match by interface in `inet` tables, switching
+    /// this masquerade rule to dual-stack would implicitly opt us into IPv6
+    /// NAT/NAT66 policy as well. That is a larger design decision than this
+    /// hook should make on its own. Until odorobo has an intentional IPv6
+    /// guest-networking story, we keep host-only NAT scoped to IPv4.
+    fn ensure_nat_rules(_bridge: &str, _subnet: &str, upstream_iface: &str) -> Result<(), Report> {
         let table = Table::new(c"nat", ProtoFamily::Ipv4);
 
         let mut postrouting_chain = nftnl::Chain::new(c"postrouting", &table);
@@ -158,14 +172,18 @@ impl NetworkAgentActor {
         batch.add(&postrouting_chain, MsgType::Add);
 
         let mut postrouting_rule = Rule::new(&postrouting_chain);
+        let upstream_iface = InterfaceName::Exact(
+            CString::new(upstream_iface)
+                .wrap_err("upstream interface name contained interior NUL")?,
+        );
         postrouting_rule.add_expr(&nft_expr!(meta oifname));
-        postrouting_rule.add_expr(&nft_expr!(cmp == upstream_iface));
+        postrouting_rule.add_expr(&nft_expr!(cmp == &upstream_iface));
         postrouting_rule.add_expr(&nft_expr!(masquerade));
         batch.add(&postrouting_rule, MsgType::Add);
 
         let finalized = batch.finalize();
-        self.send_nft_batch(&finalized).wrap_err_with(|| {
-            format!("failed to apply nftables postrouting masquerade for {upstream_iface}")
+        Self::send_nft_batch(&finalized).wrap_err_with(|| {
+            format!("failed to apply nftables postrouting masquerade for {upstream_iface:?}")
         })?;
 
         Ok(())
@@ -180,8 +198,6 @@ impl Actor for NetworkAgentActor {
 
         let (connection, handle, _) = rtnetlink::new_connection()?;
         let netlink_thread = tokio::spawn(connection);
-        let nft_socket = mnl::Socket::new(mnl::Bus::Netfilter)
-            .wrap_err("failed to create netfilter netlink socket")?;
 
         let common = match args.network_mode.clone() {
             NetworkMode::HostonlyNat {
@@ -239,14 +255,16 @@ impl Actor for NetworkAgentActor {
             None
         };
 
-        let mut actor = Self {
+        let actor = Self {
             config: args,
             common,
             dhcp_actor,
             netlink_thread,
             netlink_handle: handle,
-            nft_socket,
         };
+
+        let common_bridge = actor.common.bridge.clone();
+        let common_subnet = actor.common.subnet.clone();
 
         match actor.config.network_mode.clone() {
             NetworkMode::HostonlyNat {
@@ -272,12 +290,11 @@ impl Actor for NetworkAgentActor {
                     )
                 })?;
 
-                actor
-                    .ensure_nat_rules(&actor.common.bridge, &actor.common.subnet, &upstream_iface)
+                Self::ensure_nat_rules(&common_bridge, &common_subnet, &upstream_iface)
                     .wrap_err_with(|| {
                         format!(
                             "failed to ensure nftables NAT rules for bridge {} and upstream {}",
-                            actor.common.bridge, upstream_iface
+                            common_bridge, upstream_iface
                         )
                     })?;
             }

--- a/odorobo-agent/src/networking/actor.rs
+++ b/odorobo-agent/src/networking/actor.rs
@@ -15,6 +15,8 @@ use tracing::info;
 
 pub struct DhcpActor {
     pub config: DhcpConfig,
+    bridge: String,
+    dnsmasq_process: Option<tokio::process::Child>,
 }
 
 pub struct NetworkConfigCommon {
@@ -23,11 +25,49 @@ pub struct NetworkConfigCommon {
 }
 
 impl Actor for DhcpActor {
-    type Args = DhcpConfig;
+    type Args = (DhcpConfig, String);
     type Error = Report;
     async fn on_start(args: Self::Args, _actor_ref: ActorRef<Self>) -> Result<Self, Self::Error> {
-        // todo: actually run dnsmasq on startup
-        Ok(Self { config: args })
+        let (config, bridge) = args;
+        let dhcp_range = format!(
+            "{},{},{},{}",
+            config.range.0,
+            config.range.1,
+            config.subnet.netmask(),
+            config.lease_time
+        );
+
+        let dnsmasq_process = tokio::process::Command::new("dnsmasq")
+            .arg("--interface")
+            .arg(&bridge)
+            .arg("--bind-interfaces")
+            .arg("--dhcp-range")
+            .arg(&dhcp_range)
+            .arg("--no-daemon")
+            .spawn()
+            .wrap_err_with(|| format!("failed to start dnsmasq on bridge {bridge}"))?;
+
+        Ok(Self {
+            config,
+            bridge,
+            dnsmasq_process: Some(dnsmasq_process),
+        })
+    }
+
+    async fn on_stop(
+        &mut self,
+        _actor_ref: WeakActorRef<Self>,
+        _reason: ActorStopReason,
+    ) -> std::result::Result<(), Self::Error> {
+        if let Some(mut dnsmasq_process) = self.dnsmasq_process.take() {
+            dnsmasq_process
+                .start_kill()
+                .wrap_err_with(|| format!("failed to stop dnsmasq on bridge {}", self.bridge))?;
+
+            let _ = dnsmasq_process.wait().await;
+        }
+
+        Ok(())
     }
 }
 
@@ -200,7 +240,7 @@ impl NetworkAgentActor {
     /// NAT/NAT66 policy as well. That is a larger design decision than this
     /// hook should make on its own. Until odorobo has an intentional IPv6
     /// guest-networking story, we keep host-only NAT scoped to IPv4.
-    /// 
+    ///
     // todo: IPv6, refer to libvirt's impl:
     // ```nft
     // table ip6 libvirt_network {
@@ -210,22 +250,21 @@ impl NetworkAgentActor {
     //                 counter packets 0 bytes 0 jump guest_input
     //                 counter packets 0 bytes 0 jump guest_output
     //         }
-    
+
     //         chain guest_output {
     //         }
-    
+
     //         chain guest_input {
     //         }
-    
+
     //         chain guest_cross {
     //         }
-    
+
     //         chain guest_nat {
     //                 type nat hook postrouting priority srcnat; policy accept;
     //         }
     // }
     // ```
-    
 
     fn ensure_nat_rules(_bridge: &str, _subnet: &str, upstream_iface: &str) -> Result<(), Report> {
         const TABLE_NAME: &str = "odorobo";
@@ -337,7 +376,10 @@ impl Actor for NetworkAgentActor {
         };
 
         let dhcp_actor = if let Some(dhcp_config) = &args.dhcp_config {
-            Some(DhcpActor::spawn_link(&actor_ref, dhcp_config.clone()).await)
+            Some(
+                DhcpActor::spawn_link(&actor_ref, (dhcp_config.clone(), common.bridge.clone()))
+                    .await,
+            )
         } else {
             None
         };

--- a/odorobo-agent/src/networking/messages.rs
+++ b/odorobo-agent/src/networking/messages.rs
@@ -1,4 +1,4 @@
-use stable_eyre::Result;
+use ulid::Ulid;
 
 /// Ensures the agent-global networking state is present and configured.
 ///
@@ -15,7 +15,7 @@ pub struct EnsureHostNetwork;
 #[derive(Debug, Clone)]
 pub struct AttachTap {
     /// VM identifier for logging and future bookkeeping.
-    pub vmid: String,
+    pub vmid: Ulid,
     /// Host TAP device name created for this VM by Cloud Hypervisor.
     pub tap_name: String,
 }
@@ -27,7 +27,7 @@ pub struct AttachTap {
 #[derive(Debug, Clone)]
 pub struct DetachTap {
     /// VM identifier for logging and future bookkeeping.
-    pub vmid: String,
+    pub vmid: Ulid,
     /// Host TAP device name previously attached for this VM.
     pub tap_name: String,
 }
@@ -51,10 +51,7 @@ pub struct NetworkStatus {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AttachedTap {
     /// VM identifier associated with the TAP.
-    pub vmid: String,
+    pub vmid: Ulid,
     /// Host TAP device name.
     pub tap_name: String,
 }
-
-/// Convenience alias for local networking actor replies.
-pub type NetworkResult<T> = Result<T>;

--- a/odorobo-agent/src/networking/messages.rs
+++ b/odorobo-agent/src/networking/messages.rs
@@ -1,0 +1,60 @@
+use stable_eyre::Result;
+
+/// Ensures the agent-global networking state is present and configured.
+///
+/// This is intended for local actor-to-actor use inside the agent process and
+/// should not be exposed as a remote/shared message.
+#[derive(Debug, Clone, Default)]
+pub struct EnsureHostNetwork;
+
+/// Attaches a Cloud Hypervisor-created TAP device to the agent-managed network.
+///
+/// The TAP device is expected to already exist by the time this message is sent,
+/// typically from a post-boot provisioning hook once runtime interface details
+/// are known.
+#[derive(Debug, Clone)]
+pub struct AttachTap {
+    /// VM identifier for logging and future bookkeeping.
+    pub vmid: String,
+    /// Host TAP device name created for this VM by Cloud Hypervisor.
+    pub tap_name: String,
+}
+
+/// Detaches a TAP device from the agent-managed network.
+///
+/// This is optional for now, but defining it up front keeps the local message
+/// API stable when stop-time cleanup is added later.
+#[derive(Debug, Clone)]
+pub struct DetachTap {
+    /// VM identifier for logging and future bookkeeping.
+    pub vmid: String,
+    /// Host TAP device name previously attached for this VM.
+    pub tap_name: String,
+}
+
+/// Requests a snapshot of the local networking actor state.
+#[derive(Debug, Clone, Default)]
+pub struct Status;
+
+/// Local networking status snapshot returned by the networking actor.
+#[derive(Debug, Clone, Default)]
+pub struct NetworkStatus {
+    /// Whether host-global networking initialization has completed successfully.
+    pub initialized: bool,
+    /// Configured bridge device managed by the actor, if any.
+    pub bridge: Option<String>,
+    /// TAP devices currently tracked as attached to the managed bridge.
+    pub attached_taps: Vec<AttachedTap>,
+}
+
+/// Bookkeeping entry for an attached TAP device.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AttachedTap {
+    /// VM identifier associated with the TAP.
+    pub vmid: String,
+    /// Host TAP device name.
+    pub tap_name: String,
+}
+
+/// Convenience alias for local networking actor replies.
+pub type NetworkResult<T> = Result<T>;

--- a/odorobo-agent/src/networking/mod.rs
+++ b/odorobo-agent/src/networking/mod.rs
@@ -1,0 +1,1 @@
+pub mod messages;

--- a/odorobo-agent/src/networking/mod.rs
+++ b/odorobo-agent/src/networking/mod.rs
@@ -1,1 +1,2 @@
+pub mod actor;
 pub mod messages;

--- a/odorobo-agent/src/state/instance.rs
+++ b/odorobo-agent/src/state/instance.rs
@@ -198,7 +198,6 @@ impl VMInstance {
 
         let receive_migration_data = models::ReceiveMigrationData {
             receiver_url: receiver_uri.clone(),
-            ..Default::default()
         };
 
         let vm_id = self.vm_id().to_string();

--- a/odorobo-agent/src/state/instance.rs
+++ b/odorobo-agent/src/state/instance.rs
@@ -106,10 +106,12 @@ impl VMInstance {
 
         let vm_config = self.info().await?.config;
 
+        debug!(vmid = self.vm_id(), "before_boot hooks invoked");
         self.hook_manager
             .before_boot(self.vm_id(), &vm_config)
             .await?;
 
+        debug!(vmid = self.vm_id(), "boot_vm invoked");
         self.conn()
             .boot_vm()
             .await
@@ -120,6 +122,7 @@ impl VMInstance {
 
         let vm_info_postboot = self.info().await?;
 
+        debug!(vmid = self.vm_id(), "after_boot hooks invoked");
         self.hook_manager
             .after_boot(self.vm_id(), &vm_info_postboot)
             .await?;
@@ -498,7 +501,7 @@ impl VMInstance {
                 self.vm_id()
             ))?;
 
-        // self.save_config(&config)?;
+        self.vm_config = Some(transformed_config.clone());
 
         trace!(vm_id = self.vm_id(), "Creating VM via CH API");
         self.conn()

--- a/odorobo-agent/src/state/instance.rs
+++ b/odorobo-agent/src/state/instance.rs
@@ -396,6 +396,7 @@ impl VMInstance {
         );
         if let Ok(info) = self.info().await {
             trace!(vm_id = self.vm_id(), state = ?info.state, "Checking VM state before destroy");
+            self.hook_manager.before_stop(self.vm_id(), &info).await?;
             if matches!(
                 info.state,
                 models::VmState::Running | models::VmState::Paused

--- a/odorobo-agent/src/state/provisioning/hooks/mod.rs
+++ b/odorobo-agent/src/state/provisioning/hooks/mod.rs
@@ -10,6 +10,7 @@
 use async_trait::async_trait;
 use cloud_hypervisor_client::models::{VmConfig, VmInfo};
 use stable_eyre::Result;
+use tracing::info;
 
 mod machined;
 mod networking;
@@ -76,16 +77,28 @@ impl HookManager {
     }
 
     pub async fn before_boot(&self, vmid: &str, config: &VmConfig) -> Result<()> {
+        info!(
+            vmid = vmid,
+            hook_count = self.hooks.len(),
+            "running before_boot hooks"
+        );
         for hook in &self.hooks {
             hook.before_boot(vmid, config).await?;
         }
+        info!(vmid = vmid, "completed before_boot hooks");
         Ok(())
     }
 
     pub async fn after_boot(&self, vmid: &str, config: &VmInfo) -> Result<()> {
+        info!(
+            vmid = vmid,
+            hook_count = self.hooks.len(),
+            "running after_boot hooks"
+        );
         for hook in &self.hooks {
             hook.after_boot(vmid, config).await?;
         }
+        info!(vmid = vmid, "completed after_boot hooks");
         Ok(())
     }
 }

--- a/odorobo-agent/src/state/provisioning/hooks/mod.rs
+++ b/odorobo-agent/src/state/provisioning/hooks/mod.rs
@@ -12,6 +12,7 @@ use cloud_hypervisor_client::models::{VmConfig, VmInfo};
 use stable_eyre::Result;
 
 mod machined;
+mod networking;
 
 // Rust 1.75 does not support dyn async traits, we still need async_trait for this
 #[async_trait]
@@ -92,7 +93,10 @@ impl HookManager {
 impl Default for HookManager {
     fn default() -> Self {
         Self {
-            hooks: vec![Box::new(machined::CHMachineProvisioningHook)],
+            hooks: vec![
+                Box::new(machined::CHMachineProvisioningHook),
+                Box::new(networking::NetworkProvisioningHook),
+            ],
         }
     }
 }

--- a/odorobo-agent/src/state/provisioning/hooks/networking.rs
+++ b/odorobo-agent/src/state/provisioning/hooks/networking.rs
@@ -6,6 +6,7 @@ use stable_eyre::{
     Result,
     eyre::{WrapErr, eyre},
 };
+use tracing::info;
 use ulid::Ulid;
 
 use crate::networking::{
@@ -32,6 +33,7 @@ fn tap_names(info: &VmInfo) -> Vec<String> {
         .as_ref()
         .map(|nets| {
             nets.iter()
+                .filter(|net| net.id.as_deref().is_some_and(|id| id.starts_with("net://")))
                 .filter_map(|net| net.tap.clone())
                 .collect::<Vec<_>>()
         })
@@ -40,15 +42,21 @@ fn tap_names(info: &VmInfo) -> Vec<String> {
 
 #[async_trait]
 impl ProvisioningHook for NetworkProvisioningHook {
-    // CH auto-generates TAP names for each network device and create them if they don't
-    // already exist, so we are okay with the tap names we get from the VM config
+    // Only Odorobo-managed `net://` network IDs participate in bridge attach/detach
+    // handling here. Other network devices are left alone.
     async fn after_boot(&self, vmid: &str, config: &VmInfo) -> Result<()> {
         let vmid = Ulid::from_string(vmid)
             .map_err(|err| eyre!("invalid vmid {vmid}: {err}"))
             .wrap_err("failed to parse vmid for networking hook")?;
 
         let taps = tap_names(config);
+        info!(
+            vmid = %vmid,
+            tap_count = taps.len(),
+            "networking after_boot hook invoked for Odorobo-managed net:// TAP devices"
+        );
         if taps.is_empty() {
+            info!(vmid = %vmid, "no TAP devices present after boot, skipping network attach");
             return Ok(());
         }
 
@@ -57,6 +65,7 @@ impl ProvisioningHook for NetworkProvisioningHook {
             .wrap_err("failed to look up network actor")?;
 
         for tap_name in taps {
+            info!(vmid = %vmid, tap = %tap_name, "sending AttachTap to network actor");
             network_actor
                 .ask(AttachTap {
                     vmid,
@@ -76,7 +85,13 @@ impl ProvisioningHook for NetworkProvisioningHook {
             .wrap_err("failed to parse vmid for networking hook")?;
 
         let taps = tap_names(config);
+        info!(
+            vmid = %vmid,
+            tap_count = taps.len(),
+            "networking before_stop hook invoked for Odorobo-managed net:// TAP devices"
+        );
         if taps.is_empty() {
+            info!(vmid = %vmid, "no TAP devices present before stop, skipping network detach");
             return Ok(());
         }
 
@@ -85,6 +100,7 @@ impl ProvisioningHook for NetworkProvisioningHook {
             .wrap_err("failed to look up network actor")?;
 
         for tap_name in taps {
+            info!(vmid = %vmid, tap = %tap_name, "sending DetachTap to network actor");
             network_actor
                 .ask(DetachTap {
                     vmid,

--- a/odorobo-agent/src/state/provisioning/hooks/networking.rs
+++ b/odorobo-agent/src/state/provisioning/hooks/networking.rs
@@ -1,0 +1,100 @@
+//! Networking hook for provisioning.
+use async_trait::async_trait;
+use cloud_hypervisor_client::models::VmInfo;
+use kameo::prelude::*;
+use stable_eyre::{
+    Result,
+    eyre::{WrapErr, eyre},
+};
+use ulid::Ulid;
+
+use crate::networking::{
+    actor::NetworkAgentActor,
+    messages::{AttachTap, DetachTap},
+};
+
+use super::ProvisioningHook;
+
+/// Provisioning hook that attaches Cloud Hypervisor TAP devices to the
+/// agent-managed bridge after the VM has booted.
+pub struct NetworkProvisioningHook;
+
+async fn network_agent() -> Result<ActorRef<NetworkAgentActor>> {
+    ActorRef::<NetworkAgentActor>::lookup("network_actor")
+        .await
+        .map_err(|e| eyre!(e))?
+        .ok_or_else(|| eyre!("network actor not found"))
+}
+
+fn tap_names(info: &VmInfo) -> Vec<String> {
+    info.config
+        .net
+        .as_ref()
+        .map(|nets| {
+            nets.iter()
+                .filter_map(|net| net.tap.clone())
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default()
+}
+
+#[async_trait]
+impl ProvisioningHook for NetworkProvisioningHook {
+    // CH auto-generates TAP names for each network device and create them if they don't
+    // already exist, so we are okay with the tap names we get from the VM config
+    async fn after_boot(&self, vmid: &str, config: &VmInfo) -> Result<()> {
+        let vmid = Ulid::from_string(vmid)
+            .map_err(|err| eyre!("invalid vmid {vmid}: {err}"))
+            .wrap_err("failed to parse vmid for networking hook")?;
+
+        let taps = tap_names(config);
+        if taps.is_empty() {
+            return Ok(());
+        }
+
+        let network_actor = network_agent()
+            .await
+            .wrap_err("failed to look up network actor")?;
+
+        for tap_name in taps {
+            network_actor
+                .ask(AttachTap {
+                    vmid,
+                    tap_name: tap_name.clone(),
+                })
+                .await
+                .map_err(|err| eyre!(err))
+                .wrap_err_with(|| format!("failed to send AttachTap for tap {tap_name}"))?;
+        }
+
+        Ok(())
+    }
+
+    async fn before_stop(&self, vmid: &str, config: &VmInfo) -> Result<()> {
+        let vmid = Ulid::from_string(vmid)
+            .map_err(|err| eyre!("invalid vmid {vmid}: {err}"))
+            .wrap_err("failed to parse vmid for networking hook")?;
+
+        let taps = tap_names(config);
+        if taps.is_empty() {
+            return Ok(());
+        }
+
+        let network_actor = network_agent()
+            .await
+            .wrap_err("failed to look up network actor")?;
+
+        for tap_name in taps {
+            network_actor
+                .ask(DetachTap {
+                    vmid,
+                    tap_name: tap_name.clone(),
+                })
+                .await
+                .map_err(|err| eyre!(err))
+                .wrap_err_with(|| format!("failed to send DetachTap for tap {tap_name}"))?;
+        }
+
+        Ok(())
+    }
+}

--- a/odorobo-agent/src/state/transform/mod.rs
+++ b/odorobo-agent/src/state/transform/mod.rs
@@ -12,9 +12,11 @@ pub trait ConfigTransform: Send + Sync {
 }
 
 pub mod console;
+pub mod networking;
 pub mod path_verify;
 pub mod storage;
 pub use console::ConsoleTransform;
+pub use networking::NetworkTransform;
 pub use path_verify::PathVerify;
 use tracing::trace;
 
@@ -58,6 +60,7 @@ impl Default for TransformChain {
         Self::new()
             .add(storage::StorageDriverTransformer::default())
             .add(ConsoleTransform)
+            .add(NetworkTransform)
             .add(PathVerify)
     }
 }

--- a/odorobo-agent/src/state/transform/networking.rs
+++ b/odorobo-agent/src/state/transform/networking.rs
@@ -1,0 +1,195 @@
+use cloud_hypervisor_client::models::{NetConfig, VmConfig};
+use stable_eyre::{
+    Result,
+    eyre::{WrapErr, eyre},
+};
+use tracing::info;
+
+use super::ConfigTransform;
+
+/// Rewrites odorobo-local network URI references into deterministic TAP device names.
+///
+/// Expected input shape:
+/// - `net.id = Some("net://<network_id>")`
+///
+/// Rewritten output:
+/// - `net.id = Some("net://<network_id>")`
+/// - `net.tap = Some("vmtap-<vmid>-<network_id>")`
+///
+/// This lets Cloud Hypervisor use a known TAP name instead of relying on runtime
+/// auto-generated TAP names, which are not reflected back in VM info reliably,
+/// while preserving the Odorobo-local URI marker for later hook logic.
+///
+/// Notes:
+/// - The TAP name is deterministic per `(vmid, network_id)`.
+/// - We intentionally do not create the TAP device here yet; this transformer only
+///   mutates the VM config into a host-specific concrete value.
+/// - `network_id` is restricted to a conservative character set suitable for Linux
+///   interface naming and CH IDs.
+#[derive(Debug, Clone)]
+pub struct NetworkTransform;
+
+const NETWORK_URI_PREFIX: &str = "net://";
+const TAP_PREFIX: &str = "vmtap";
+const MAX_IFNAME_LEN: usize = 15;
+
+impl ConfigTransform for NetworkTransform {
+    #[tracing::instrument(skip(config))]
+    fn transform(&self, vmid: &str, config: &mut VmConfig) -> Result<()> {
+        let Some(nets) = config.net.as_mut() else {
+            return Ok(());
+        };
+
+        for net in nets.iter_mut() {
+            rewrite_net_config(vmid, net)?;
+        }
+
+        Ok(())
+    }
+}
+
+fn rewrite_net_config(vmid: &str, net: &mut NetConfig) -> Result<()> {
+    let Some(id) = net.id.as_deref() else {
+        return Ok(());
+    };
+
+    let Some(network_id) = id.strip_prefix(NETWORK_URI_PREFIX) else {
+        return Ok(());
+    };
+
+    validate_network_id(network_id).wrap_err_with(|| format!("invalid network URI id {id}"))?;
+
+    let tap_name = deterministic_tap_name(vmid, network_id);
+
+    info!(
+        vmid = vmid,
+        network_id = network_id,
+        tap = tap_name,
+        "rewriting network URI to deterministic TAP device"
+    );
+
+    net.id = Some(id.to_string());
+    net.tap = Some(tap_name);
+
+    Ok(())
+}
+
+fn validate_network_id(network_id: &str) -> Result<()> {
+    if network_id.is_empty() {
+        return Err(eyre!("network id must not be empty"));
+    }
+
+    if !network_id
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        return Err(eyre!(
+            "network id must contain only ASCII alphanumeric characters, '-' or '_'"
+        ));
+    }
+
+    Ok(())
+}
+
+fn deterministic_tap_name(vmid: &str, network_id: &str) -> String {
+    let mut vmid_part = sanitize_component(vmid);
+    let mut network_part = sanitize_component(network_id);
+
+    // Linux interface names are typically limited to 15 bytes.
+    // Prefer keeping some of both the VMID and network id rather than truncating
+    // one side entirely. For VMIDs we keep the suffix rather than the prefix,
+    // because ULID prefixes are timestamp-derived and less useful for uniqueness.
+    let separator_len = 2; // two '-'
+    let fixed_len = TAP_PREFIX.len() + separator_len;
+    let available = MAX_IFNAME_LEN.saturating_sub(fixed_len);
+
+    if available == 0 {
+        return TAP_PREFIX[..MAX_IFNAME_LEN.min(TAP_PREFIX.len())].to_string();
+    }
+
+    let half = available / 2;
+    let vmid_budget = half.max(1);
+    let network_budget = available.saturating_sub(vmid_budget).max(1);
+
+    if vmid_part.len() > vmid_budget {
+        vmid_part = vmid_part[vmid_part.len() - vmid_budget..].to_string();
+    }
+    if network_part.len() > network_budget {
+        network_part = network_part[network_part.len() - network_budget..].to_string();
+    }
+
+    let mut tap = format!("{TAP_PREFIX}-{vmid_part}-{network_part}");
+    if tap.len() > MAX_IFNAME_LEN {
+        tap.truncate(MAX_IFNAME_LEN);
+    }
+    tap
+}
+
+fn sanitize_component(value: &str) -> String {
+    value
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cloud_hypervisor_client::models::VmConfig;
+
+    #[test]
+    fn rewrites_net_uri_into_tap_and_plain_id() {
+        let mut config = VmConfig {
+            net: Some(vec![NetConfig {
+                id: Some("net://devnet".to_string()),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        };
+
+        NetworkTransform
+            .transform("01KPB9AMVWXC2D1PF4W6E7MHWT", &mut config)
+            .unwrap();
+
+        let net = &config.net.as_ref().unwrap()[0];
+        assert_eq!(net.id.as_deref(), Some("net://devnet"));
+        assert_eq!(net.tap.as_deref(), Some("vmtap-7mhwt-vnet"));
+    }
+
+    #[test]
+    fn ignores_non_network_uri_ids() {
+        let mut config = VmConfig {
+            net: Some(vec![NetConfig {
+                id: Some("net1".to_string()),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        };
+
+        NetworkTransform.transform("vmid", &mut config).unwrap();
+
+        let net = &config.net.as_ref().unwrap()[0];
+        assert_eq!(net.id.as_deref(), Some("net1"));
+        assert!(net.tap.is_none());
+    }
+
+    #[test]
+    fn rejects_invalid_network_id() {
+        let mut config = VmConfig {
+            net: Some(vec![NetConfig {
+                id: Some("net://bad/id".to_string()),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        };
+
+        let err = NetworkTransform.transform("vmid", &mut config).unwrap_err();
+        assert!(err.to_string().contains("invalid network URI id"));
+    }
+}

--- a/odorobo-agent/src/state/transform/networking.rs
+++ b/odorobo-agent/src/state/transform/networking.rs
@@ -159,7 +159,7 @@ mod tests {
 
         let net = &config.net.as_ref().unwrap()[0];
         assert_eq!(net.id.as_deref(), Some("net://devnet"));
-        assert_eq!(net.tap.as_deref(), Some("vmtap-7mhwt-vnet"));
+        assert_eq!(net.tap.as_deref(), Some("vmtap-mhwt-vnet"));
     }
 
     #[test]


### PR DESCRIPTION
Implement a `NetworkAgentActor` that deals with L3 routing for individual VMs, called upon by a stateless hook that reads the `VmInfo` and does the L3 routing for them.

Consider adding Open vSwitch integration or something on here too if we're into that kind of thing, but yea. I am trying to be vendor-agnostic for this so we will be rawdogging netlink and maybe iptables OR nftables.

closes #17 